### PR TITLE
Fix temporary table name

### DIFF
--- a/cohortextractor/query_engines/mssql.py
+++ b/cohortextractor/query_engines/mssql.py
@@ -152,7 +152,8 @@ class MssqlQueryEngine(BaseQueryEngine):
         # make a table object representing a temporary table into which we will write the required
         # values
         for i, (group, output_nodes) in enumerate(self.output_groups.items()):
-            table_name = f"group_table_{i}"
+            # The `#` prefix makes this a session-scoped temporary table
+            table_name = f"#group_table_{i}"
             columns = {self.get_output_column_name(output) for output in output_nodes}
             self.output_group_tables[group] = make_table_expression(
                 table_name, {"patient_id"} | columns

--- a/tests/recordings/test_extract::test_pick_a_single_value.recording
+++ b/tests/recordings/test_extract::test_pick_a_single_value.recording
@@ -102,14 +102,14 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.patient_id \n'
    'FROM (SELECT EventCode AS code, Date AS date, PatientId AS patient_id \n'
    'FROM events) AS clinical_events\n'
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id \n'
    'FROM practice_registrations) AS practice_registrations GROUP BY '
@@ -117,11 +117,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS '
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
    'code \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_date_in_range_filter.recording
+++ b/tests/recordings/test_query_engine::test_date_in_range_filter.recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -453,7 +459,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT anon_1.patient_id, anon_1.result \n'
    'FROM (SELECT clinical_events.patient_id AS patient_id, '
    'clinical_events.result AS result, row_number() OVER (PARTITION BY '
@@ -466,7 +472,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT anon_1.patient_id, anon_1.stp \n'
    'FROM (SELECT practice_registrations.patient_id AS patient_id, '
    'practice_registrations.stp AS stp, row_number() OVER (PARTITION BY '
@@ -482,7 +488,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_2 FROM (\n'
+   'SELECT * INTO #group_table_2 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -491,12 +497,13 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_2.patient_id AS patient_id, group_table_0.result AS '
-   'value, group_table_1.stp AS stp \n'
-   'FROM group_table_2 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_2.patient_id = group_table_0.patient_id LEFT OUTER JOIN '
-   'group_table_1 ON group_table_2.patient_id = group_table_1.patient_id \n'
-   'WHERE group_table_2.patient_id_exists = 1',
+   'SELECT [#group_table_2].patient_id AS patient_id, [#group_table_0].result '
+   'AS value, [#group_table_1].stp AS stp \n'
+   'FROM [#group_table_2] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_2].patient_id = [#group_table_0].patient_id LEFT OUTER JOIN '
+   '[#group_table_1] ON [#group_table_2].patient_id = '
+   '[#group_table_1].patient_id \n'
+   'WHERE [#group_table_2].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_extract_get_single_column.recording
+++ b/tests/recordings/test_query_engine::test_extract_get_single_column.recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -311,7 +317,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.patient_id \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
    'PatientId AS patient_id \n'
@@ -319,7 +325,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -328,11 +334,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS '
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
    'output_value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_filter_between_other_query_values.recording
+++ b/tests/recordings/test_query_engine::test_filter_between_other_query_values.recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -581,7 +587,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT anon_1.patient_id, anon_1.test_date \n'
    'FROM (SELECT positive_tests.patient_id AS patient_id, '
    'positive_tests.test_date AS test_date, row_number() OVER (PARTITION BY '
@@ -594,7 +600,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT anon_1.patient_id, anon_1.test_date \n'
    'FROM (SELECT positive_tests.patient_id AS patient_id, '
    'positive_tests.test_date AS test_date, row_number() OVER (PARTITION BY '
@@ -608,7 +614,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_2 FROM (\n'
+   'SELECT * INTO #group_table_2 FROM (\n'
    'SELECT anon_1.date, anon_1.patient_id, anon_1.result \n'
    'FROM (SELECT clinical_events.date AS date, clinical_events.patient_id AS '
    'patient_id, clinical_events.result AS result, row_number() OVER (PARTITION '
@@ -616,17 +622,18 @@
    '_row_num \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
    'PatientId AS patient_id \n'
-   'FROM events) AS clinical_events LEFT OUTER JOIN group_table_0 ON '
-   'group_table_0.patient_id = clinical_events.patient_id LEFT OUTER JOIN '
-   'group_table_1 ON group_table_1.patient_id = clinical_events.patient_id \n'
+   'FROM events) AS clinical_events LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_0].patient_id = clinical_events.patient_id LEFT OUTER JOIN '
+   '[#group_table_1] ON [#group_table_1].patient_id = '
+   'clinical_events.patient_id \n'
    "WHERE clinical_events.code = N'Code1' AND clinical_events.date >= "
-   'group_table_0.test_date AND clinical_events.date <= '
-   'group_table_1.test_date) AS anon_1 \n'
+   '[#group_table_0].test_date AND clinical_events.date <= '
+   '[#group_table_1].test_date) AS anon_1 \n'
    'WHERE anon_1._row_num = 1\n'
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_3 FROM (\n'
+   'SELECT * INTO #group_table_3 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -635,15 +642,16 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_3.patient_id AS patient_id, group_table_0.test_date AS '
-   'first_pos, group_table_1.test_date AS last_pos, group_table_2.date AS '
-   'date, group_table_2.result AS value \n'
-   'FROM group_table_3 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_3.patient_id = group_table_0.patient_id LEFT OUTER JOIN '
-   'group_table_1 ON group_table_3.patient_id = group_table_1.patient_id LEFT '
-   'OUTER JOIN group_table_2 ON group_table_3.patient_id = '
-   'group_table_2.patient_id \n'
-   'WHERE group_table_3.patient_id_exists = 1',
+   'SELECT [#group_table_3].patient_id AS patient_id, '
+   '[#group_table_0].test_date AS first_pos, [#group_table_1].test_date AS '
+   'last_pos, [#group_table_2].date AS date, [#group_table_2].result AS '
+   'value \n'
+   'FROM [#group_table_3] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_3].patient_id = [#group_table_0].patient_id LEFT OUTER JOIN '
+   '[#group_table_1] ON [#group_table_3].patient_id = '
+   '[#group_table_1].patient_id LEFT OUTER JOIN [#group_table_2] ON '
+   '[#group_table_3].patient_id = [#group_table_2].patient_id \n'
+   'WHERE [#group_table_3].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_multiple_columns.recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_multiple_columns.recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -360,7 +366,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.patient_id \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
    'PatientId AS patient_id \n'
@@ -368,14 +374,14 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT positive_tests.patient_id, positive_tests.result \n'
    'FROM (SELECT PositiveResult AS result, PatientId AS patient_id \n'
    'FROM pos_tests) AS positive_tests\n'
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_2 FROM (\n'
+   'SELECT * INTO #group_table_2 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -384,12 +390,13 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_2.patient_id AS patient_id, group_table_0.code AS '
-   'output_value, group_table_1.result AS positive \n'
-   'FROM group_table_2 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_2.patient_id = group_table_0.patient_id LEFT OUTER JOIN '
-   'group_table_1 ON group_table_2.patient_id = group_table_1.patient_id \n'
-   'WHERE group_table_2.patient_id_exists = 1',
+   'SELECT [#group_table_2].patient_id AS patient_id, [#group_table_0].code AS '
+   'output_value, [#group_table_1].result AS positive \n'
+   'FROM [#group_table_2] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_2].patient_id = [#group_table_0].patient_id LEFT OUTER JOIN '
+   '[#group_table_1] ON [#group_table_2].patient_id = '
+   '[#group_table_1].patient_id \n'
+   'WHERE [#group_table_2].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_default_population.recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_default_population.recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -311,7 +317,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.patient_id \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
    'PatientId AS patient_id \n'
@@ -319,7 +325,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -328,11 +334,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS '
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
    'output_value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_specified_population.recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_specified_population.recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -311,7 +317,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.patient_id \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
    'PatientId AS patient_id \n'
@@ -319,7 +325,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -328,11 +334,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS '
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
    'output_value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_single_row_per_patient[code_output0-date_output0-expected0].recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_single_row_per_patient[code_output0-date_output0-expected0].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -390,7 +396,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT anon_1.code, anon_1.patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
    'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
@@ -402,7 +408,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT anon_1.date, anon_1.patient_id \n'
    'FROM (SELECT clinical_events.date AS date, clinical_events.patient_id AS '
    'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
@@ -414,7 +420,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_2 FROM (\n'
+   'SELECT * INTO #group_table_2 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -423,12 +429,13 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_2.patient_id AS patient_id, group_table_0.code AS '
-   'code_value, group_table_1.date AS date_value \n'
-   'FROM group_table_2 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_2.patient_id = group_table_0.patient_id LEFT OUTER JOIN '
-   'group_table_1 ON group_table_2.patient_id = group_table_1.patient_id \n'
-   'WHERE group_table_2.patient_id_exists = 1',
+   'SELECT [#group_table_2].patient_id AS patient_id, [#group_table_0].code AS '
+   'code_value, [#group_table_1].date AS date_value \n'
+   'FROM [#group_table_2] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_2].patient_id = [#group_table_0].patient_id LEFT OUTER JOIN '
+   '[#group_table_1] ON [#group_table_2].patient_id = '
+   '[#group_table_1].patient_id \n'
+   'WHERE [#group_table_2].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_single_row_per_patient[code_output1-date_output1-expected1].recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_single_row_per_patient[code_output1-date_output1-expected1].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -390,7 +396,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT anon_1.code, anon_1.patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
    'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
@@ -402,7 +408,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT anon_1.date, anon_1.patient_id \n'
    'FROM (SELECT clinical_events.date AS date, clinical_events.patient_id AS '
    'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
@@ -414,7 +420,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_2 FROM (\n'
+   'SELECT * INTO #group_table_2 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -423,12 +429,13 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_2.patient_id AS patient_id, group_table_0.code AS '
-   'code_value, group_table_1.date AS date_value \n'
-   'FROM group_table_2 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_2.patient_id = group_table_0.patient_id LEFT OUTER JOIN '
-   'group_table_1 ON group_table_2.patient_id = group_table_1.patient_id \n'
-   'WHERE group_table_2.patient_id_exists = 1',
+   'SELECT [#group_table_2].patient_id AS patient_id, [#group_table_0].code AS '
+   'code_value, [#group_table_1].date AS date_value \n'
+   'FROM [#group_table_2] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_2].patient_id = [#group_table_0].patient_id LEFT OUTER JOIN '
+   '[#group_table_1] ON [#group_table_2].patient_id = '
+   '[#group_table_1].patient_id \n'
+   'WHERE [#group_table_2].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test between filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test between filter].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -420,7 +426,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -429,11 +435,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on date data].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on numeric data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on numeric data].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test greater than or equals filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test greater than or equals filter on date data].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test in filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test in filter].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test less than filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test less than filter on date data].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on date data].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on numeric data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on numeric data].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test multiple chained filters].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test multiple chained filters].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -421,7 +427,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -430,11 +436,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test multiple equals filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test multiple equals filter].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -420,7 +426,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -429,11 +435,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test not equals filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test not equals filter].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test not in filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test not in filter].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test on or after filter (alias for gte)].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test on or after filter (alias for gte)].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test on or before filter (alias for lte)].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test on or before filter (alias for lte)].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test single equals filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test single equals filter].recording
@@ -59,7 +59,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('practice_registrations',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -80,7 +80,7 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('events',)),
  ('Cursor', 'close', (), {}, None),
  ('Cursor',
   'execute',
@@ -101,8 +101,14 @@
   (),
   {},
   (('TABLE_NAME', 1, None, None, None, None, None),)),
- ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'fetchone', (), {}, ('pos_tests',)),
  ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE pos_tests', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE events', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
+ ('Cursor', 'execute', ('\nDROP TABLE practice_registrations', {}), {}, None),
+ ('Cursor', 'description', (), {}, None),
  ('Connection', 'commit', (), {}, None),
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
@@ -409,7 +415,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO group_table_0 FROM (\n'
+  ('SELECT * INTO #group_table_0 FROM (\n'
    'SELECT clinical_events.code, clinical_events.date, '
    'clinical_events.patient_id, clinical_events.result \n'
    'FROM (SELECT EventCode AS code, Date AS date, ResultValue AS result, '
@@ -419,7 +425,7 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT * INTO group_table_1 FROM (\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
    'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
    'FROM (SELECT PatientId AS patient_id, StpId AS stp, StartDate AS '
    'date_start, EndDate AS date_end \n'
@@ -428,11 +434,11 @@
    ') t\n'
    '\n'
    '\n'
-   'SELECT group_table_1.patient_id AS patient_id, group_table_0.code AS code, '
-   'group_table_0.date AS date, group_table_0.result AS value \n'
-   'FROM group_table_1 LEFT OUTER JOIN group_table_0 ON '
-   'group_table_1.patient_id = group_table_0.patient_id \n'
-   'WHERE group_table_1.patient_id_exists = 1',
+   'SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
+   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
+   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
+   'WHERE [#group_table_1].patient_id_exists = 1',
    {}),
   {},
   None),


### PR DESCRIPTION
The `#` prefix on the table name makes it a session-scoped local
temporary table:
https://stackoverflow.com/questions/2920836/local-and-global-temporary-tables-in-sql-server

For bonus fun, because of this naming scheme SQL Server folk sometimes
refer to these as "hash tables".