### PR TITLE
Add directory containing cohort definition to path

### DIFF
--- a/cohortextractor/__main__.py
+++ b/cohortextractor/__main__.py
@@ -5,11 +5,20 @@ from pathlib import Path
 from .main import main
 
 
+def existing_python_file(value):
+    path = Path(value)
+    if not path.exists():
+        raise ValueError(f"{value} does not exit")
+    if not path.suffix == ".py":
+        raise ValueError(f"{value} is not a Python file")
+    return path
+
+
 parser = ArgumentParser(description="Generate cohorts in OpenSAFELY")
 parser.add_argument(
     "--cohort-definition",
     help="The path of the file where the cohort is defined",
-    type=Path,
+    type=existing_python_file,
 )
 parser.add_argument(
     "--output",

--- a/tests/fixtures/end_to_end_tests/cohort_lib.py
+++ b/tests/fixtures/end_to_end_tests/cohort_lib.py
@@ -1,0 +1,5 @@
+from cohortextractor import table
+
+
+def clinical_events():
+    return table("clinical_events")

--- a/tests/fixtures/end_to_end_tests/my_cohort.py
+++ b/tests/fixtures/end_to_end_tests/my_cohort.py
@@ -1,6 +1,6 @@
-from cohortextractor import table
+from cohort_lib import clinical_events
 
 
 class Cohort:
-    date = table("clinical_events").get("date")
-    event = table("clinical_events").get("code")
+    date = clinical_events().get("date")
+    event = clinical_events().get("code")

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -17,6 +17,9 @@ class Study:
     def definition(self):
         return self._path / "my_cohort.py"
 
+    def code(self):
+        return self._path.glob("*.py")
+
     def expected_results(self):
         return self._path / "results.csv"
 
@@ -35,7 +38,8 @@ def cohort_extractor_in_container(tmpdir, database, containers):
     output_host_path = workspace / output_rel_path
 
     def run(study):
-        shutil.copy(study.definition(), analysis_dir)
+        for file in study.code():
+            shutil.copy(file, analysis_dir)
         definition_path = Path("analysis") / study.definition().name
 
         containers.run_fg(
@@ -68,7 +72,8 @@ def cohort_extractor_in_process(tmpdir, database, containers):
     output_host_path = workspace / output_rel_path
 
     def run(study):
-        shutil.copy(study.definition(), analysis_dir)
+        for file in study.code():
+            shutil.copy(file, analysis_dir)
         definition_path = analysis_dir / study.definition().name
 
         main(


### PR DESCRIPTION
This allows researchers to factor out code from the cohort definition
into local library modules, as demonstrated by the end-to-end test.