### PR TITLE
Make the ephemeral test database session-based

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ def database(request, real_db, dummy_db, recording):
         is_smoke_test(request) and is_integration_test(request)
     ), "A test cannot be both a smoke test and an integration test"
 
-    if is_smoke_test(request) or playback.recording_mode() == "record":
+    if is_smoke_test(request) or recording.mode == "record":
         yield real_db(recording)
     else:
         yield dummy_db
@@ -132,7 +132,7 @@ def setup_test_database(database, recording, request):
     db_url = database.host_url()
 
     def setup(input_data, drivername="mssql+pymssql", base=mock_backend.Base):
-        if is_integration_test(request) and playback.recording_mode() == "playback":
+        if is_integration_test(request) and recording.mode == "playback":
             # Since we suspend recording during setup, we must skip it altogether during playback.
             return
 

--- a/tests/lib/docker.py
+++ b/tests/lib/docker.py
@@ -8,9 +8,12 @@ class Containers:
     def __init__(self, docker_client):
         self._docker = docker_client
 
+    def get_container(self, name):
+        return self._docker.containers.get(name)
+
     def is_running(self, name):
         try:
-            container = self._docker.containers.get(name)
+            container = self.get_container(name)
             return container.status == "running"
         except docker.errors.NotFound:
             return False


### PR DESCRIPTION
The `recording` fixture needs to remain function-scoped, otherwise it doesn't have access to the specific test data it needs for recording, as does the `setup_database` fixture, so it can set up the data for each test.  Since we can't mix fixture scopes, we can't just make the database a session-scoped fixture, so the docker client, network and database are now set on the session itself, and the fixtures just retrieve them. 