### PR TITLE
Ignore dummy-data-file arg on real backend

### DIFF
--- a/cohortextractor/main.py
+++ b/cohortextractor/main.py
@@ -14,7 +14,7 @@ def main(definition_path, output_file, backend_id, db_url, dummy_data_file=None)
     cohort = load_cohort(definition_path)
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    if dummy_data_file:
+    if dummy_data_file and not db_url:
         validate_dummy_data(cohort, dummy_data_file, output_file)
         shutil.copyfile(dummy_data_file, output_file)
     else:

--- a/tests/fixtures/end_to_end_tests/invalid_dummy_data.csv
+++ b/tests/fixtures/end_to_end_tests/invalid_dummy_data.csv
@@ -1,0 +1,2 @@
+patient_id,date,event,extra_col
+Foo,2021-01-01 00:00:00,xyz

--- a/tests/recordings/test_end_to_end::test_extracts_data_from_sql_server_ignores_dummy_data_file.recording
+++ b/tests/recordings/test_end_to_end::test_extracts_data_from_sql_server_ignores_dummy_data_file.recording
@@ -1,0 +1,101 @@
+[('Cursor', 'execute', ('select @@version', {}), {}, None),
+ ('Cursor', 'description', (), {}, (('', 1, None, None, None, None, None),)),
+ ('Cursor',
+  'fetchone',
+  (),
+  {},
+  ('Microsoft SQL Server 2017 (RTM-CU25) (KB5003830) - 14.0.3401.7 (X64) \n'
+   '\tJun 25 2021 14:02:48 \n'
+   '\tCopyright (C) 2017 Microsoft Corporation\n'
+   '\tDeveloper Edition (64-bit) on Linux (Ubuntu 16.04.7 LTS)',)),
+ ('Cursor', 'close', (), {}, None),
+ ('Cursor', 'execute', ('SELECT schema_name()', {}), {}, None),
+ ('Cursor', 'description', (), {}, (('', 1, None, None, None, None, None),)),
+ ('Cursor', 'fetchone', (), {}, ('dbo',)),
+ ('Cursor', 'close', (), {}, None),
+ ('Cursor',
+  'execute',
+  ('\n'
+   '                  SELECT CASE transaction_isolation_level\n'
+   '                    WHEN 0 THEN NULL\n'
+   "                    WHEN 1 THEN 'READ UNCOMMITTED'\n"
+   "                    WHEN 2 THEN 'READ COMMITTED'\n"
+   "                    WHEN 3 THEN 'REPEATABLE READ'\n"
+   "                    WHEN 4 THEN 'SERIALIZABLE'\n"
+   "                    WHEN 5 THEN 'SNAPSHOT' END AS "
+   'TRANSACTION_ISOLATION_LEVEL\n'
+   '                    FROM sys.dm_exec_sessions\n'
+   '                    where session_id = @@SPID\n'
+   '                  ',),
+  {},
+  None),
+ ('Cursor', 'fetchone', (), {}, ('READ COMMITTED',)),
+ ('Cursor', 'close', (), {}, None),
+ ('Cursor',
+  'execute',
+  ("SELECT CAST('test max support' AS NVARCHAR(max))", {}),
+  {},
+  None),
+ ('Cursor', 'description', (), {}, (('', 1, None, None, None, None, None),)),
+ ('Cursor', 'fetchone', (), {}, ('test max support',)),
+ ('Cursor', 'close', (), {}, None),
+ ('Connection', 'rollback', (), {}, None),
+ ('Cursor',
+  'execute',
+  ('SELECT * INTO #group_table_0 FROM (\n'
+   'SELECT clinical_events.date, clinical_events.patient_id \n'
+   'FROM (SELECT CTV3Code AS code, ConsultationDate AS date, NumericValue AS '
+   'numeric_value, Patient_ID AS patient_id \n'
+   'FROM [CodedEvent]) AS clinical_events\n'
+   ') t\n'
+   '\n'
+   '\n'
+   'SELECT * INTO #group_table_1 FROM (\n'
+   'SELECT clinical_events.code, clinical_events.patient_id \n'
+   'FROM (SELECT CTV3Code AS code, ConsultationDate AS date, NumericValue AS '
+   'numeric_value, Patient_ID AS patient_id \n'
+   'FROM [CodedEvent]) AS clinical_events\n'
+   ') t\n'
+   '\n'
+   '\n'
+   'SELECT * INTO #group_table_2 FROM (\n'
+   'SELECT practice_registrations.patient_id, 1 AS patient_id_exists \n'
+   'FROM (\n'
+   '            SELECT RegistrationHistory.Patient_ID AS patient_id,\n'
+   '                RegistrationHistory.StartDate AS date_start,\n'
+   '                RegistrationHistory.EndDate AS date_end,\n'
+   '                Organisation.Organisation_ID AS pseudo_id,\n'
+   '                Organisation.Region as nuts1_region_name\n'
+   '            FROM RegistrationHistory\n'
+   '            LEFT OUTER JOIN Organisation ON '
+   'RegistrationHistory.Organisation_ID = Organisation.Organisation_ID\n'
+   '        ) AS practice_registrations GROUP BY '
+   'practice_registrations.patient_id\n'
+   ') t\n'
+   '\n'
+   '\n'
+   'SELECT [#group_table_2].patient_id AS patient_id, [#group_table_0].date AS '
+   'date, [#group_table_1].code AS event \n'
+   'FROM [#group_table_2] LEFT OUTER JOIN [#group_table_0] ON '
+   '[#group_table_2].patient_id = [#group_table_0].patient_id LEFT OUTER JOIN '
+   '[#group_table_1] ON [#group_table_2].patient_id = '
+   '[#group_table_1].patient_id \n'
+   'WHERE [#group_table_2].patient_id_exists = 1',
+   {}),
+  {},
+  None),
+ ('Cursor',
+  'description',
+  (),
+  {},
+  (('patient_id', 3, None, None, None, None, None),
+   ('date', 4, None, None, None, None, None),
+   ('event', 1, None, None, None, None, None))),
+ ('Cursor',
+  'fetchone',
+  (),
+  {},
+  (1, datetime.datetime(2021, 1, 1, 0, 0), 'xyz')),
+ ('Cursor', 'fetchone', (), {}, None),
+ ('Cursor', 'close', (), {}, None),
+ ('Connection', 'rollback', (), {}, None)]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -9,8 +9,9 @@ from cohortextractor.main import main
 
 
 class Study:
-    def __init__(self, study_path):
+    def __init__(self, study_path, dummy_data_file=None):
         self._path = Path(__file__).parent.absolute() / "fixtures" / study_path
+        self.dummy_data_file = dummy_data_file or "dummy_data.csv"
 
     def definition(self):
         return self._path / "my_cohort.py"
@@ -22,7 +23,7 @@ class Study:
         return self._path / "results.csv"
 
     def dummy_data(self):
-        return self._path / "dummy_data.csv"
+        return self._path / self.dummy_data_file
 
 
 @pytest.fixture
@@ -161,15 +162,15 @@ def test_extracts_data_from_sql_server_integration_test(
     run_test(load_study, setup_tpp_database, cohort_extractor_in_process)
 
 
-def run_test(load_study, setup_tpp_database, cohort_extractor):
+def run_test(load_study, setup_tpp_database, cohort_extractor, dummy_data_file=None):
     setup_tpp_database(
         Patient(Patient_ID=1),
         Events(Patient_ID=1, ConsultationDate="2021-01-01", CTV3Code="xyz"),
         RegistrationHistory(Patient_ID=1),
     )
 
-    study = load_study("end_to_end_tests")
-    actual_results = cohort_extractor(study)
+    study = load_study("end_to_end_tests", dummy_data_file)
+    actual_results = cohort_extractor(study, use_dummy_data=dummy_data_file is not None)
     assert_results_equivalent(actual_results, study.expected_results())
 
 
@@ -177,3 +178,17 @@ def test_dummy_data(load_study, cohort_extractor_in_process_no_database):
     study = load_study("end_to_end_tests")
     actual_results = cohort_extractor_in_process_no_database(study, use_dummy_data=True)
     assert_results_equivalent(actual_results, study.expected_results())
+
+
+@pytest.mark.integration
+def test_extracts_data_from_sql_server_ignores_dummy_data_file(
+    load_study, setup_tpp_database, cohort_extractor_in_process
+):
+    # A dummy data file is ignored if running in a real backend (i.e. DATABASE_URL is set)
+    # THis provides an invalid dummy data file, but it is ignored so no errors are raised
+    run_test(
+        load_study,
+        setup_tpp_database,
+        cohort_extractor_in_process,
+        "invalid_dummy_data.csv",
+    )


### PR DESCRIPTION
This means that the `run` command in a project.yaml can specify --dummy-data-file and it will only be used in a local run.  On a real backend (where `DATABASE_URL` is set), it will be ignored.