### PR TITLE
Ensure that cohorts contain only one row per patient

### DIFF
--- a/cohortextractor/query_utils.py
+++ b/cohortextractor/query_utils.py
@@ -1,11 +1,17 @@
+from .query_language import Value
+
+
 def get_class_vars(cls):
     default_vars = set(dir(type("ArbitraryEmptyClass", (), {})))
     return [(key, value) for key, value in vars(cls).items() if key not in default_vars]
 
 
 def get_column_definitions(cohort_cls):
-    return {
-        key: value
-        for key, value in get_class_vars(cohort_cls)
-        if not key.startswith("_")
-    }
+    columns = {}
+    for name, value in get_class_vars(cohort_cls):
+        if name.startswith("_"):
+            continue
+        if not isinstance(value, Value):
+            raise ValueError(f"Cohort variable '{name}' is not a Value")
+        columns[name] = value
+    return columns

--- a/tests/acceptance/test_full_long_covid_study.py
+++ b/tests/acceptance/test_full_long_covid_study.py
@@ -89,7 +89,7 @@ class Cohort:
     age_group = categorise(_age_categories, default="missing")
 
     # Sex
-    sex = table("patients").get("sex")
+    sex = table("patients").first_by("patient_id").get("sex")
 
     # Region
     region = _current_registrations.get("nuts1_region_name")

--- a/tests/acceptance/test_simplified_long_covid_study.py
+++ b/tests/acceptance/test_simplified_long_covid_study.py
@@ -64,7 +64,7 @@ class SimplifiedCohort:
         "80+": _age >= 80,
     }
     age_group = categorise(_age_categories, default="missing")
-    sex = table("patients").get("sex")
+    sex = table("patients").first_by("patient_id").get("sex")
 
 
 # Add the Long covid code count variables

--- a/tests/fixtures/end_to_end_tests/my_cohort.py
+++ b/tests/fixtures/end_to_end_tests/my_cohort.py
@@ -2,5 +2,5 @@ from cohort_lib import clinical_events
 
 
 class Cohort:
-    date = clinical_events().get("date")
-    event = clinical_events().get("code")
+    date = clinical_events().first_by("patient_id").get("date")
+    event = clinical_events().first_by("patient_id").get("code")

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -63,6 +63,10 @@ class Events(Base):
     ResultValue = sqlalchemy.Column(sqlalchemy.Float)
 
 
+def event(code, date, value=None):
+    return Events(EventCode=code, Date=date, ResultValue=value)
+
+
 class PositiveTests(Base):
     __tablename__ = "pos_tests"
     Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
@@ -77,3 +81,14 @@ class Patients(Base):
     PatientId = sqlalchemy.Column(sqlalchemy.Integer)
     Height = sqlalchemy.Column(sqlalchemy.Float)
     DateOfBirth = sqlalchemy.Column(sqlalchemy.Date)
+
+
+def patient(patient_id, *entities):
+    entities = list(entities)
+    if not filter(lambda e: isinstance(e, RegistrationHistory), entities):
+        entities.append(
+            RegistrationHistory(StartDate="1900-01-01", EndDate="2999-12-31")
+        )
+    for entity in entities:
+        entity.PatientId = patient_id
+    return [Patients(PatientId=patient_id), *entities]

--- a/tests/recordings/test_end_to_end::test_extracts_data_from_sql_server_ignores_dummy_data_file.recording
+++ b/tests/recordings/test_end_to_end::test_extracts_data_from_sql_server_ignores_dummy_data_file.recording
@@ -43,24 +43,30 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.date AS date, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.date AS date, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [CTV3Code] AS code, [ConsultationDate] AS date, '
    '[NumericValue] AS numeric_value, [Patient_ID] AS patient_id \n'
-   'FROM [CodedEvent]) AS clinical_events) AS anon_1',
-   {}),
+   'FROM [CodedEvent]) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [CTV3Code] AS code, [ConsultationDate] AS date, '
    '[NumericValue] AS numeric_value, [Patient_ID] AS patient_id \n'
-   'FROM [CodedEvent]) AS clinical_events) AS anon_1',
-   {}),
+   'FROM [CodedEvent]) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_end_to_end::test_extracts_data_from_sql_server_integration_test.recording
+++ b/tests/recordings/test_end_to_end::test_extracts_data_from_sql_server_integration_test.recording
@@ -43,24 +43,30 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.date AS date, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.date AS date, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [CTV3Code] AS code, [ConsultationDate] AS date, '
    '[NumericValue] AS numeric_value, [Patient_ID] AS patient_id \n'
-   'FROM [CodedEvent]) AS clinical_events) AS anon_1',
-   {}),
+   'FROM [CodedEvent]) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [CTV3Code] AS code, [ConsultationDate] AS date, '
    '[NumericValue] AS numeric_value, [Patient_ID] AS patient_id \n'
-   'FROM [CodedEvent]) AS clinical_events) AS anon_1',
-   {}),
+   'FROM [CodedEvent]) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_extract::test_pick_a_single_value.recording
+++ b/tests/recordings/test_extract::test_pick_a_single_value.recording
@@ -43,12 +43,15 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
-   'FROM events) AS clinical_events) AS anon_1',
-   {}),
+   'FROM events) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_full_long_covid_study::test_cohort.recording
+++ b/tests/recordings/test_full_long_covid_study::test_cohort.recording
@@ -1133,11 +1133,15 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_11 \n'
-   'FROM (SELECT patients.patient_id AS patient_id, patients.sex AS sex \n'
+   'FROM (SELECT anon_2.patient_id AS patient_id, anon_2.sex AS sex \n'
+   'FROM (SELECT patients.patient_id AS patient_id, patients.sex AS sex, '
+   'row_number() OVER (PARTITION BY patients.patient_id ORDER BY '
+   'patients.patient_id) AS _row_num \n'
    'FROM (SELECT [Sex] AS sex, [DateOfBirth] AS date_of_birth, [Patient_ID] AS '
    'patient_id \n'
-   'FROM [Patient]) AS patients) AS anon_1',
-   {}),
+   'FROM [Patient]) AS patients) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_query_engine::test_date_in_range_filter.recording
+++ b/tests/recordings/test_query_engine::test_date_in_range_filter.recording
@@ -43,16 +43,20 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT anon_2.patient_id AS patient_id, anon_2.result AS result \n'
-   'FROM (SELECT clinical_events.patient_id AS patient_id, '
-   'clinical_events.result AS result, row_number() OVER (PARTITION BY '
-   'clinical_events.patient_id ORDER BY clinical_events.date DESC) AS '
-   '_row_num \n'
-   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
-   '[PatientId] AS patient_id \n'
-   'FROM events) AS clinical_events) AS anon_2 \n'
+   'FROM (SELECT anon_2.patient_id AS patient_id, anon_2.stp AS stp \n'
+   'FROM (SELECT practice_registrations.patient_id AS patient_id, '
+   'practice_registrations.stp AS stp, row_number() OVER (PARTITION BY '
+   'practice_registrations.patient_id ORDER BY '
+   'practice_registrations.patient_id) AS _row_num \n'
+   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
+   'date_end, [PatientId] AS patient_id \n'
+   'FROM practice_registrations) AS practice_registrations \n'
+   'WHERE practice_registrations.date_start <= %(date_start_1)s AND '
+   'practice_registrations.date_end >= %(date_end_1)s) AS anon_2 \n'
    'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
-   {'row_num_1': 1}),
+   {'date_start_1': '2021-03-02T00:00:00',
+    'date_end_1': '2021-03-02T00:00:00',
+    'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
@@ -60,12 +64,13 @@
   'execute',
   ('SELECT * INTO #group_table_1 \n'
    'FROM (SELECT practice_registrations.patient_id AS patient_id, '
-   'practice_registrations.stp AS stp \n'
+   'count(practice_registrations.patient_id) AS patient_id_count \n'
    'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
    'date_end, [PatientId] AS patient_id \n'
    'FROM practice_registrations) AS practice_registrations \n'
    'WHERE practice_registrations.date_start <= %(date_start_1)s AND '
-   'practice_registrations.date_end >= %(date_end_1)s) AS anon_1',
+   'practice_registrations.date_end >= %(date_end_1)s GROUP BY '
+   'practice_registrations.patient_id) AS anon_1',
    {'date_start_1': '2021-03-02T00:00:00',
     'date_end_1': '2021-03-02T00:00:00'}),
   {},
@@ -86,8 +91,8 @@
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_2].patient_id AS patient_id, [#group_table_0].result '
-   'AS value, [#group_table_1].stp AS stp \n'
+  ('SELECT [#group_table_2].patient_id AS patient_id, [#group_table_0].stp AS '
+   'stp, [#group_table_1].patient_id_count AS count \n'
    'FROM [#group_table_2] LEFT OUTER JOIN [#group_table_0] ON '
    '[#group_table_2].patient_id = [#group_table_0].patient_id LEFT OUTER JOIN '
    '[#group_table_1] ON [#group_table_2].patient_id = '
@@ -101,13 +106,12 @@
   (),
   {},
   (('patient_id', 3, None, None, None, None, None),
-   ('value', 3, None, None, None, None, None),
-   ('stp', 1, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 10.1, 'STP1')),
- ('Cursor', 'fetchone', (), {}, (2, 10.2, None)),
- ('Cursor', 'fetchone', (), {}, (3, 10.3, 'STP2')),
- ('Cursor', 'fetchone', (), {}, (4, 10.4, 'STP2')),
- ('Cursor', 'fetchone', (), {}, (4, 10.4, 'STP3')),
+   ('stp', 1, None, None, None, None, None),
+   ('count', 3, None, None, None, None, None))),
+ ('Cursor', 'fetchone', (), {}, (1, 'STP1', 1)),
+ ('Cursor', 'fetchone', (), {}, (2, None, None)),
+ ('Cursor', 'fetchone', (), {}, (3, 'STP2', 1)),
+ ('Cursor', 'fetchone', (), {}, (4, 'STP2', 2)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_extract_get_single_column.recording
+++ b/tests/recordings/test_query_engine::test_extract_get_single_column.recording
@@ -43,12 +43,15 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
-   'FROM events) AS clinical_events) AS anon_1',
-   {}),
+   'FROM events) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_multiple_columns.recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_multiple_columns.recording
@@ -43,24 +43,31 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
-   'FROM events) AS clinical_events) AS anon_1',
-   {}),
+   'FROM events) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
+   'FROM (SELECT anon_2.patient_id AS patient_id, anon_2.result AS result \n'
    'FROM (SELECT positive_tests.patient_id AS patient_id, '
-   'positive_tests.result AS result \n'
+   'positive_tests.result AS result, row_number() OVER (PARTITION BY '
+   'positive_tests.patient_id ORDER BY positive_tests.patient_id) AS '
+   '_row_num \n'
    'FROM (SELECT [PositiveResult] AS result, [TestDate] AS test_date, '
    '[PatientId] AS patient_id \n'
-   'FROM pos_tests) AS positive_tests) AS anon_1',
-   {}),
+   'FROM pos_tests) AS positive_tests) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_default_population.recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_default_population.recording
@@ -43,12 +43,15 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
-   'FROM events) AS clinical_events) AS anon_1',
-   {}),
+   'FROM events) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_specified_population.recording
+++ b/tests/recordings/test_query_engine::test_run_generated_sql_get_single_column_specified_population.recording
@@ -43,12 +43,15 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
-   'FROM events) AS clinical_events) AS anon_1',
-   {}),
+   'FROM events) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_query_engine::test_simple_filters[test between filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test between filter].recording
@@ -43,38 +43,43 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
    'WHERE clinical_events.date >= %(date_1)s AND clinical_events.date <= '
-   '%(date_2)s) AS anon_1',
-   {'date_1': '2021-01-15', 'date_2': '2021-05-03'}),
+   '%(date_2)s GROUP BY clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'date_1': '2021-01-02', 'date_2': '2021-01-04'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.date >= %(date_1)s AND clinical_events.date <= '
+   '%(date_2)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'date_1': '2021-01-02', 'date_2': '2021-01-04', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -86,10 +91,9 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 2, 1), 20.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code2', datetime.date(2021, 5, 2), 30.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code3', datetime.date(2021, 5, 3), 40.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 2, 1), 60.1)),
+ ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 1, 2), 20.0)),
+ ('Cursor', 'fetchone', (), {}, (3, 'Code3', datetime.date(2021, 1, 3), 30.0)),
+ ('Cursor', 'fetchone', (), {}, (4, 'Code4', datetime.date(2021, 1, 4), 40.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on date data].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.date > %(date_1)s) AS anon_1',
-   {'date_1': '2021-05-03'}),
+   'WHERE clinical_events.date > %(date_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'date_1': '2021-01-02'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.date > %(date_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'date_1': '2021-01-02', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,8 +90,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, None, None, None)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code1', datetime.date(2021, 6, 5), 50.1)),
+ ('Cursor', 'fetchone', (), {}, (3, 'Code3', datetime.date(2021, 1, 3), 30.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on numeric data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test greater than filter on numeric data].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.result > %(result_1)s) AS anon_1',
-   {'result_1': 40}),
+   'WHERE clinical_events.result > %(result_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'result_1': 20}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.result > %(result_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'result_1': 20, 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,9 +90,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code3', datetime.date(2021, 5, 3), 40.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code1', datetime.date(2021, 6, 5), 50.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 2, 1), 60.1)),
+ ('Cursor', 'fetchone', (), {}, (3, 'Code3', datetime.date(2021, 1, 3), 30.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test greater than or equals filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test greater than or equals filter on date data].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.date >= %(date_1)s) AS anon_1',
-   {'date_1': '2021-05-03'}),
+   'WHERE clinical_events.date >= %(date_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'date_1': '2021-01-02'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.date >= %(date_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'date_1': '2021-01-02', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,8 +90,8 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code3', datetime.date(2021, 5, 3), 40.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code1', datetime.date(2021, 6, 5), 50.1)),
+ ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 1, 2), 20.0)),
+ ('Cursor', 'fetchone', (), {}, (3, 'Code3', datetime.date(2021, 1, 3), 30.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test in filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test in filter].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.code IN (%(code_1_1)s, %(code_1_2)s)) AS anon_1',
-   {'code_1_1': 'Code2', 'code_1_2': 'Code3'}),
+   'WHERE clinical_events.code IN (%(code_1_1)s, %(code_1_2)s) GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'code_1_1': 'Code1', 'code_1_2': 'Code999'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.code IN (%(code_1_1)s, %(code_1_2)s)) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1, 'code_1_1': 'Code1', 'code_1_2': 'Code999'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,9 +90,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code2', datetime.date(2021, 5, 2), 30.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code3', datetime.date(2021, 5, 3), 40.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 2, 1), 60.1)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test less than filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test less than filter on date data].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.date < %(date_1)s) AS anon_1',
-   {'date_1': '2021-02-01'}),
+   'WHERE clinical_events.date < %(date_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'date_1': '2021-01-02'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.date < %(date_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'date_1': '2021-01-02', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,8 +90,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 3), 10.1)),
- ('Cursor', 'fetchone', (), {}, (2, None, None, None)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on date data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on date data].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.date <= %(date_1)s) AS anon_1',
-   {'date_1': '2021-02-01'}),
+   'WHERE clinical_events.date <= %(date_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'date_1': '2021-01-02'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.date <= %(date_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'date_1': '2021-01-02', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,9 +90,8 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 3), 10.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 2, 1), 20.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 2, 1), 60.1)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
+ ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 1, 2), 20.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on numeric data].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test less than or equals filter on numeric data].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.result <= %(result_1)s) AS anon_1',
-   {'result_1': 20.2}),
+   'WHERE clinical_events.result <= %(result_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'result_1': 20}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.result <= %(result_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'result_1': 20, 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,9 +90,8 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 3), 10.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 2, 1), 20.1)),
- ('Cursor', 'fetchone', (), {}, (2, None, None, None)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
+ ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 1, 2), 20.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test multiple chained filters].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test multiple chained filters].recording
@@ -43,42 +43,53 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.code = %(code_1)s AND clinical_events.result < '
-   '%(result_1)s AND clinical_events.date >= %(date_1)s AND '
-   'clinical_events.date <= %(date_2)s) AS anon_1',
-   {'code_1': 'Code1',
-    'result_1': 50,
-    'date_1': '2021-01-15',
-    'date_2': '2021-06-06'}),
+   'WHERE clinical_events.result > %(result_1)s AND clinical_events.date >= '
+   '%(date_1)s AND clinical_events.date <= %(date_2)s AND clinical_events.code '
+   '= %(code_1)s GROUP BY clinical_events.patient_id) AS anon_1',
+   {'param_1': 1,
+    'result_1': 15,
+    'date_1': '2021-01-03',
+    'date_2': '2021-06-06',
+    'code_1': 'Code4'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.result > %(result_1)s AND clinical_events.date >= '
+   '%(date_1)s AND clinical_events.date <= %(date_2)s AND clinical_events.code '
+   '= %(code_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'result_1': 15,
+    'date_1': '2021-01-03',
+    'date_2': '2021-06-06',
+    'code_1': 'Code4',
+    'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -90,8 +101,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 2, 1), 20.1)),
- ('Cursor', 'fetchone', (), {}, (2, None, None, None)),
+ ('Cursor', 'fetchone', (), {}, (4, 'Code4', datetime.date(2021, 1, 4), 40.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test multiple equals filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test multiple equals filter].recording
@@ -43,38 +43,43 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
    'WHERE clinical_events.code = %(code_1)s AND clinical_events.date = '
-   '%(date_1)s) AS anon_1',
-   {'code_1': 'Code1', 'date_1': '2021-02-01'}),
+   '%(date_1)s GROUP BY clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'code_1': 'Code1', 'date_1': '2021-01-01'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.code = %(code_1)s AND clinical_events.date = '
+   '%(date_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'code_1': 'Code1', 'date_1': '2021-01-01', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -86,8 +91,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 2, 1), 20.1)),
- ('Cursor', 'fetchone', (), {}, (2, None, None, None)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test not equals filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test not equals filter].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.code != %(code_1)s) AS anon_1',
-   {'code_1': 'Code1'}),
+   'WHERE clinical_events.code != %(code_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'code_1': 'Code2'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.code != %(code_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'code_1': 'Code2', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,9 +90,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code2', datetime.date(2021, 5, 2), 30.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code3', datetime.date(2021, 5, 3), 40.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 2, 1), 60.1)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test not in filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test not in filter].recording
@@ -43,38 +43,43 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE (clinical_events.code NOT IN (%(code_1_1)s, %(code_1_2)s))) AS '
-   'anon_1',
-   {'code_1_1': 'Code1', 'code_1_2': 'Code2'}),
+   'WHERE (clinical_events.code NOT IN (%(code_1_1)s, %(code_1_2)s)) GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'code_1_1': 'Code1', 'code_1_2': 'Code999'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE (clinical_events.code NOT IN (%(code_1_1)s, %(code_1_2)s))) AS '
+   'anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1, 'code_1_1': 'Code1', 'code_1_2': 'Code999'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -86,8 +91,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code3', datetime.date(2021, 5, 3), 40.1)),
- ('Cursor', 'fetchone', (), {}, (2, None, None, None)),
+ ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 1, 2), 20.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test on or after filter (alias for gte)].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test on or after filter (alias for gte)].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.date >= %(date_1)s) AS anon_1',
-   {'date_1': '2021-05-03'}),
+   'WHERE clinical_events.date >= %(date_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'date_1': '2021-01-02'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.date >= %(date_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'date_1': '2021-01-02', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,8 +90,8 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code3', datetime.date(2021, 5, 3), 40.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code1', datetime.date(2021, 6, 5), 50.1)),
+ ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 1, 2), 20.0)),
+ ('Cursor', 'fetchone', (), {}, (3, 'Code3', datetime.date(2021, 1, 3), 30.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test on or before filter (alias for lte)].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test on or before filter (alias for lte)].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.date <= %(date_1)s) AS anon_1',
-   {'date_1': '2021-02-01'}),
+   'WHERE clinical_events.date <= %(date_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'date_1': '2021-01-02'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.date <= %(date_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'date_1': '2021-01-02', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,9 +90,8 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 3), 10.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 2, 1), 20.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 2, 1), 60.1)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
+ ('Cursor', 'fetchone', (), {}, (2, 'Code2', datetime.date(2021, 1, 2), 20.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_query_engine::test_simple_filters[test single equals filter].recording
+++ b/tests/recordings/test_query_engine::test_simple_filters[test single equals filter].recording
@@ -43,37 +43,42 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
-   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
-   'result \n'
+   'FROM (SELECT clinical_events.patient_id AS patient_id, %(param_1)s AS '
+   'patient_id_exists \n'
    'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
    '[PatientId] AS patient_id \n'
    'FROM events) AS clinical_events \n'
-   'WHERE clinical_events.code = %(code_1)s) AS anon_1',
-   {'code_1': 'Code1'}),
+   'WHERE clinical_events.code = %(code_1)s GROUP BY '
+   'clinical_events.patient_id) AS anon_1',
+   {'param_1': 1, 'code_1': 'Code1'}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (SELECT [StpId] AS stp, [StartDate] AS date_start, [EndDate] AS '
-   'date_end, [PatientId] AS patient_id \n'
-   'FROM practice_registrations) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id, anon_2.result AS result \n'
+   'FROM (SELECT clinical_events.code AS code, clinical_events.date AS date, '
+   'clinical_events.patient_id AS patient_id, clinical_events.result AS '
+   'result, row_number() OVER (PARTITION BY clinical_events.patient_id ORDER '
+   'BY clinical_events.patient_id) AS _row_num \n'
+   'FROM (SELECT [EventCode] AS code, [Date] AS date, [ResultValue] AS result, '
+   '[PatientId] AS patient_id \n'
+   'FROM events) AS clinical_events \n'
+   'WHERE clinical_events.code = %(code_1)s) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'code_1': 'Code1', 'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code, [#group_table_0].date AS date, [#group_table_0].result AS value \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+  ('SELECT [#group_table_0].patient_id AS patient_id, [#group_table_1].code AS '
+   'code, [#group_table_1].date AS date, [#group_table_1].result AS value \n'
+   'FROM [#group_table_0] LEFT OUTER JOIN [#group_table_1] ON '
+   '[#group_table_0].patient_id = [#group_table_1].patient_id \n'
+   'WHERE [#group_table_0].patient_id_exists = 1',
    {}),
   {},
   None),
@@ -85,9 +90,7 @@
    ('code', 1, None, None, None, None, None),
    ('date', 2, None, None, None, None, None),
    ('value', 3, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 3), 10.1)),
- ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 2, 1), 20.1)),
- ('Cursor', 'fetchone', (), {}, (2, 'Code1', datetime.date(2021, 6, 5), 50.1)),
+ ('Cursor', 'fetchone', (), {}, (1, 'Code1', datetime.date(2021, 1, 1), 10.0)),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_simplified_long_covid_study::test_simplified_cohort.recording
+++ b/tests/recordings/test_simplified_long_covid_study::test_simplified_cohort.recording
@@ -328,11 +328,15 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_7 \n'
-   'FROM (SELECT patients.patient_id AS patient_id, patients.sex AS sex \n'
+   'FROM (SELECT anon_2.patient_id AS patient_id, anon_2.sex AS sex \n'
+   'FROM (SELECT patients.patient_id AS patient_id, patients.sex AS sex, '
+   'row_number() OVER (PARTITION BY patients.patient_id ORDER BY '
+   'patients.patient_id) AS _row_num \n'
    'FROM (SELECT [Sex] AS sex, [DateOfBirth] AS date_of_birth, [Patient_ID] AS '
    'patient_id \n'
-   'FROM [Patient]) AS patients) AS anon_1',
-   {}),
+   'FROM [Patient]) AS patients) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_tpp_backend::test_basic_events_and_registration.recording
+++ b/tests/recordings/test_tpp_backend::test_basic_events_and_registration.recording
@@ -43,12 +43,15 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT clinical_events.code AS code, clinical_events.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY clinical_events.patient_id '
+   'ORDER BY clinical_events.patient_id) AS _row_num \n'
    'FROM (SELECT [CTV3Code] AS code, [ConsultationDate] AS date, '
    '[NumericValue] AS numeric_value, [Patient_ID] AS patient_id \n'
-   'FROM [CodedEvent]) AS clinical_events) AS anon_1',
-   {}),
+   'FROM [CodedEvent]) AS clinical_events) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_tpp_backend::test_hospitalization_code_parsing_works_with_filters.recording
+++ b/tests/recordings/test_tpp_backend::test_hospitalization_code_parsing_works_with_filters.recording
@@ -62,8 +62,10 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.patient_id AS patient_id \n'
    'FROM (SELECT hospitalizations.code AS code, hospitalizations.patient_id AS '
-   'patient_id \n'
+   'patient_id, row_number() OVER (PARTITION BY hospitalizations.patient_id '
+   'ORDER BY hospitalizations.patient_id) AS _row_num \n'
    'FROM (\n'
    '            SELECT Patient_ID as patient_id, Admission_Date as date, \n'
    '        REVERSE(\n'
@@ -111,8 +113,9 @@
    '     fully_split\n'
    '        ) AS hospitalizations \n'
    'WHERE hospitalizations.code IN (SELECT [#codelist_0].code \n'
-   'FROM [#codelist_0])) AS anon_1',
-   {}),
+   'FROM [#codelist_0])) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[copes with comma pipe combinations].recording
+++ b/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[copes with comma pipe combinations].recording
@@ -42,10 +42,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT hospitalizations.code AS code, hospitalizations.patient_id AS '
-   'patient_id \n'
-   'FROM (\n'
+  ('\n'
    '            SELECT Patient_ID as patient_id, Admission_Date as date, \n'
    '        REVERSE(\n'
    '            SUBSTRING(\n'
@@ -90,38 +87,7 @@
    "            ) AS t CROSS APPLY x.nodes('i') AS y(i)\n"
    '        )\n'
    '     fully_split\n'
-   '        ) AS hospitalizations) AS anon_1',
-   {}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (\n'
-   '            SELECT RegistrationHistory.Patient_ID AS patient_id,\n'
-   '                RegistrationHistory.StartDate AS date_start,\n'
-   '                RegistrationHistory.EndDate AS date_end,\n'
-   '                Organisation.Organisation_ID AS pseudo_id,\n'
-   '                Organisation.Region as nuts1_region_name\n'
-   '            FROM RegistrationHistory\n'
-   '            LEFT OUTER JOIN Organisation ON '
-   'RegistrationHistory.Organisation_ID = Organisation.Organisation_ID\n'
-   '        ) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+   '        ',
    {}),
   {},
   None),
@@ -130,11 +96,12 @@
   (),
   {},
   (('patient_id', 3, None, None, None, None, None),
+   ('date', 2, None, None, None, None, None),
    ('code', 1, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'abc')),
- ('Cursor', 'fetchone', (), {}, (1, 'def')),
- ('Cursor', 'fetchone', (), {}, (1, 'ghi')),
- ('Cursor', 'fetchone', (), {}, (1, 'jkl')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'abc')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'def')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'ghi')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'jkl')),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[returns a single code].recording
+++ b/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[returns a single code].recording
@@ -42,10 +42,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT hospitalizations.code AS code, hospitalizations.patient_id AS '
-   'patient_id \n'
-   'FROM (\n'
+  ('\n'
    '            SELECT Patient_ID as patient_id, Admission_Date as date, \n'
    '        REVERSE(\n'
    '            SUBSTRING(\n'
@@ -90,38 +87,7 @@
    "            ) AS t CROSS APPLY x.nodes('i') AS y(i)\n"
    '        )\n'
    '     fully_split\n'
-   '        ) AS hospitalizations) AS anon_1',
-   {}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (\n'
-   '            SELECT RegistrationHistory.Patient_ID AS patient_id,\n'
-   '                RegistrationHistory.StartDate AS date_start,\n'
-   '                RegistrationHistory.EndDate AS date_end,\n'
-   '                Organisation.Organisation_ID AS pseudo_id,\n'
-   '                Organisation.Region as nuts1_region_name\n'
-   '            FROM RegistrationHistory\n'
-   '            LEFT OUTER JOIN Organisation ON '
-   'RegistrationHistory.Organisation_ID = Organisation.Organisation_ID\n'
-   '        ) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+   '        ',
    {}),
   {},
   None),
@@ -130,8 +96,9 @@
   (),
   {},
   (('patient_id', 3, None, None, None, None, None),
+   ('date', 2, None, None, None, None, None),
    ('code', 1, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'flim')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'flim')),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[returns multiple space comma separated codes].recording
+++ b/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[returns multiple space comma separated codes].recording
@@ -42,10 +42,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT hospitalizations.code AS code, hospitalizations.patient_id AS '
-   'patient_id \n'
-   'FROM (\n'
+  ('\n'
    '            SELECT Patient_ID as patient_id, Admission_Date as date, \n'
    '        REVERSE(\n'
    '            SUBSTRING(\n'
@@ -90,38 +87,7 @@
    "            ) AS t CROSS APPLY x.nodes('i') AS y(i)\n"
    '        )\n'
    '     fully_split\n'
-   '        ) AS hospitalizations) AS anon_1',
-   {}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (\n'
-   '            SELECT RegistrationHistory.Patient_ID AS patient_id,\n'
-   '                RegistrationHistory.StartDate AS date_start,\n'
-   '                RegistrationHistory.EndDate AS date_end,\n'
-   '                Organisation.Organisation_ID AS pseudo_id,\n'
-   '                Organisation.Region as nuts1_region_name\n'
-   '            FROM RegistrationHistory\n'
-   '            LEFT OUTER JOIN Organisation ON '
-   'RegistrationHistory.Organisation_ID = Organisation.Organisation_ID\n'
-   '        ) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+   '        ',
    {}),
   {},
   None),
@@ -130,10 +96,11 @@
   (),
   {},
   (('patient_id', 3, None, None, None, None, None),
+   ('date', 2, None, None, None, None, None),
    ('code', 1, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'flim')),
- ('Cursor', 'fetchone', (), {}, (1, 'flam')),
- ('Cursor', 'fetchone', (), {}, (1, 'flum')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'flim')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'flam')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'flum')),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[returns multiple space double pipe separated codes].recording
+++ b/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[returns multiple space double pipe separated codes].recording
@@ -42,10 +42,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT hospitalizations.code AS code, hospitalizations.patient_id AS '
-   'patient_id \n'
-   'FROM (\n'
+  ('\n'
    '            SELECT Patient_ID as patient_id, Admission_Date as date, \n'
    '        REVERSE(\n'
    '            SUBSTRING(\n'
@@ -90,38 +87,7 @@
    "            ) AS t CROSS APPLY x.nodes('i') AS y(i)\n"
    '        )\n'
    '     fully_split\n'
-   '        ) AS hospitalizations) AS anon_1',
-   {}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (\n'
-   '            SELECT RegistrationHistory.Patient_ID AS patient_id,\n'
-   '                RegistrationHistory.StartDate AS date_start,\n'
-   '                RegistrationHistory.EndDate AS date_end,\n'
-   '                Organisation.Organisation_ID AS pseudo_id,\n'
-   '                Organisation.Region as nuts1_region_name\n'
-   '            FROM RegistrationHistory\n'
-   '            LEFT OUTER JOIN Organisation ON '
-   'RegistrationHistory.Organisation_ID = Organisation.Organisation_ID\n'
-   '        ) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+   '        ',
    {}),
   {},
   None),
@@ -130,10 +96,11 @@
   (),
   {},
   (('patient_id', 3, None, None, None, None, None),
+   ('date', 2, None, None, None, None, None),
    ('code', 1, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'flam')),
- ('Cursor', 'fetchone', (), {}, (1, 'flim')),
- ('Cursor', 'fetchone', (), {}, (1, 'flum')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'flam')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'flim')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'flum')),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[strips just trailing xs].recording
+++ b/tests/recordings/test_tpp_backend::test_hospitalization_table_code_conversion[strips just trailing xs].recording
@@ -42,10 +42,7 @@
  ('Connection', 'rollback', (), {}, None),
  ('Cursor',
   'execute',
-  ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT hospitalizations.code AS code, hospitalizations.patient_id AS '
-   'patient_id \n'
-   'FROM (\n'
+  ('\n'
    '            SELECT Patient_ID as patient_id, Admission_Date as date, \n'
    '        REVERSE(\n'
    '            SUBSTRING(\n'
@@ -90,38 +87,7 @@
    "            ) AS t CROSS APPLY x.nodes('i') AS y(i)\n"
    '        )\n'
    '     fully_split\n'
-   '        ) AS hospitalizations) AS anon_1',
-   {}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT * INTO #group_table_1 \n'
-   'FROM (SELECT practice_registrations.patient_id AS patient_id, %(param_1)s '
-   'AS patient_id_exists \n'
-   'FROM (\n'
-   '            SELECT RegistrationHistory.Patient_ID AS patient_id,\n'
-   '                RegistrationHistory.StartDate AS date_start,\n'
-   '                RegistrationHistory.EndDate AS date_end,\n'
-   '                Organisation.Organisation_ID AS pseudo_id,\n'
-   '                Organisation.Region as nuts1_region_name\n'
-   '            FROM RegistrationHistory\n'
-   '            LEFT OUTER JOIN Organisation ON '
-   'RegistrationHistory.Organisation_ID = Organisation.Organisation_ID\n'
-   '        ) AS practice_registrations GROUP BY '
-   'practice_registrations.patient_id) AS anon_1',
-   {'param_1': 1}),
-  {},
-  None),
- ('Cursor', 'description', (), {}, None),
- ('Cursor',
-  'execute',
-  ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].code AS '
-   'code \n'
-   'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
-   '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
-   'WHERE [#group_table_1].patient_id_exists = 1',
+   '        ',
    {}),
   {},
   None),
@@ -130,10 +96,11 @@
   (),
   {},
   (('patient_id', 3, None, None, None, None, None),
+   ('date', 2, None, None, None, None, None),
    ('code', 1, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, 'ABC')),
- ('Cursor', 'fetchone', (), {}, (1, 'XYZ')),
- ('Cursor', 'fetchone', (), {}, (1, 'OXO')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'ABC')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'XYZ')),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2012, 12, 12), 'OXO')),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_tpp_backend::test_hospitalization_table_returns_admission_date_and_code.recording
+++ b/tests/recordings/test_tpp_backend::test_hospitalization_table_returns_admission_date_and_code.recording
@@ -43,8 +43,12 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
-   'FROM (SELECT hospitalizations.date AS date, hospitalizations.patient_id AS '
-   'patient_id \n'
+   'FROM (SELECT anon_2.code AS code, anon_2.date AS date, anon_2.patient_id '
+   'AS patient_id \n'
+   'FROM (SELECT hospitalizations.code AS code, hospitalizations.date AS date, '
+   'hospitalizations.patient_id AS patient_id, row_number() OVER (PARTITION BY '
+   'hospitalizations.patient_id ORDER BY hospitalizations.patient_id) AS '
+   '_row_num \n'
    'FROM (\n'
    '            SELECT Patient_ID as patient_id, Admission_Date as date, \n'
    '        REVERSE(\n'
@@ -90,8 +94,9 @@
    "            ) AS t CROSS APPLY x.nodes('i') AS y(i)\n"
    '        )\n'
    '     fully_split\n'
-   '        ) AS hospitalizations) AS anon_1',
-   {}),
+   '        ) AS hospitalizations) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),
@@ -118,7 +123,7 @@
  ('Cursor',
   'execute',
   ('SELECT [#group_table_1].patient_id AS patient_id, [#group_table_0].date AS '
-   'admission \n'
+   'admission, [#group_table_0].code AS code \n'
    'FROM [#group_table_1] LEFT OUTER JOIN [#group_table_0] ON '
    '[#group_table_1].patient_id = [#group_table_0].patient_id \n'
    'WHERE [#group_table_1].patient_id_exists = 1',
@@ -130,8 +135,9 @@
   (),
   {},
   (('patient_id', 3, None, None, None, None, None),
-   ('admission', 2, None, None, None, None, None))),
- ('Cursor', 'fetchone', (), {}, (1, datetime.date(2020, 12, 12))),
+   ('admission', 2, None, None, None, None, None),
+   ('code', 1, None, None, None, None, None))),
+ ('Cursor', 'fetchone', (), {}, (1, datetime.date(2020, 12, 12), 'xyz')),
  ('Cursor', 'fetchone', (), {}, None),
  ('Cursor', 'close', (), {}, None),
  ('Connection', 'rollback', (), {}, None)]

--- a/tests/recordings/test_tpp_backend::test_patients_table.recording
+++ b/tests/recordings/test_tpp_backend::test_patients_table.recording
@@ -43,12 +43,16 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.date_of_birth AS date_of_birth, anon_2.patient_id AS '
+   'patient_id, anon_2.sex AS sex \n'
    'FROM (SELECT patients.date_of_birth AS date_of_birth, patients.patient_id '
-   'AS patient_id, patients.sex AS sex \n'
+   'AS patient_id, patients.sex AS sex, row_number() OVER (PARTITION BY '
+   'patients.patient_id ORDER BY patients.patient_id) AS _row_num \n'
    'FROM (SELECT [Sex] AS sex, [DateOfBirth] AS date_of_birth, [Patient_ID] AS '
    'patient_id \n'
-   'FROM [Patient]) AS patients) AS anon_1',
-   {}),
+   'FROM [Patient]) AS patients) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/recordings/test_tpp_backend::test_registration_dates.recording
+++ b/tests/recordings/test_tpp_backend::test_registration_dates.recording
@@ -43,9 +43,13 @@
  ('Cursor',
   'execute',
   ('SELECT * INTO #group_table_0 \n'
+   'FROM (SELECT anon_2.date_end AS date_end, anon_2.date_start AS date_start, '
+   'anon_2.patient_id AS patient_id \n'
    'FROM (SELECT practice_registrations.date_end AS date_end, '
    'practice_registrations.date_start AS date_start, '
-   'practice_registrations.patient_id AS patient_id \n'
+   'practice_registrations.patient_id AS patient_id, row_number() OVER '
+   '(PARTITION BY practice_registrations.patient_id ORDER BY '
+   'practice_registrations.patient_id) AS _row_num \n'
    'FROM (\n'
    '            SELECT RegistrationHistory.Patient_ID AS patient_id,\n'
    '                RegistrationHistory.StartDate AS date_start,\n'
@@ -55,8 +59,9 @@
    '            FROM RegistrationHistory\n'
    '            LEFT OUTER JOIN Organisation ON '
    'RegistrationHistory.Organisation_ID = Organisation.Organisation_ID\n'
-   '        ) AS practice_registrations) AS anon_1',
-   {}),
+   '        ) AS practice_registrations) AS anon_2 \n'
+   'WHERE anon_2._row_num = %(row_num_1)s) AS anon_1',
+   {'row_num_1': 1}),
   {},
   None),
  ('Cursor', 'description', (), {}, None),

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -14,7 +14,7 @@ def test_pick_a_single_value(database, setup_test_database):
     setup_test_database(input_data)
 
     class Cohort:
-        code = table("clinical_events").get("code")
+        code = table("clinical_events").first_by("patient_id").get("code")
 
     expected = [{"patient_id": 1, "code": "xyz"}]
 

--- a/tests/test_query_language.py
+++ b/tests/test_query_language.py
@@ -1,7 +1,6 @@
 import pytest
 
 from cohortextractor.query_language import (
-    Column,
     FilteredTable,
     Row,
     Table,
@@ -155,15 +154,3 @@ def test_cohort_column_definitions_multiple_equals_operators():
     penultimate_filtered_table = last_filtered_table.source
     assert penultimate_filtered_table.operator == "__eq__"
     assert penultimate_filtered_table.column == "code"
-
-
-def test_cohort_column_definitions_return_column():
-    """We can return a column as an output"""
-
-    class Cohort:
-        output_value = table("clinical_events").get("code")
-
-    column_definitions = get_column_definitions(Cohort)
-    assert isinstance(column_definitions["output_value"], Column)
-    assert column_definitions["output_value"].column == "code"
-    assert column_definitions["output_value"].source.name == "clinical_events"


### PR DESCRIPTION
We do this in the simplest way possible -- by asserting that every
cohort variable is a Value, rather than a Column. This is what
researchers will want, but unfortunately a whole bunch of our tests have
taken advantage of the fact that we could previously return Columns.

Mostly the tests are fixed by a judicious sprinkling of uniqueifying
operators, but there are a couple that needed significant
restructuring.

Working on the filter tests, I found it hard to reason about the tests
with the test data separated from the results, so I've restructured
those tests to bring the two together (and minimized the data while I
was at it).

Fixes #129.