### PR TITLE
feat: use Github cacheing of pip's cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,12 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - uses: extractions/setup-just@v1
       - name: Check formatting, linting and import sorting
         run: ./scripts/do check
@@ -26,6 +32,12 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - uses: extractions/setup-just@v1
       - name: Run tests
         env:


### PR DESCRIPTION
* only a marginal improvement to CI times (a few seconds), but keen to have this best practice be widespread around our repos
