### PR TITLE
Validate cohort

### DIFF
--- a/cohortextractor/__main__.py
+++ b/cohortextractor/__main__.py
@@ -36,6 +36,13 @@ generate_cohort_parser.add_argument(
     help="Provide dummy data from a file to be validated and used as output",
     type=Path,
 )
+generate_cohort_parser.add_argument(
+    "--validate-backend",
+    type=str,
+    nargs="?",
+    choices=["tpp", "graphnet"],
+    help="Validate the cohort definition against the specified backend",
+)
 
 generate_measures_parser = subparsers.add_parser(
     "generate_measures", help="Generate measures from cohort data"
@@ -63,8 +70,10 @@ options = parser.parse_args()
 
 
 if options.which == "generate_cohort":
-
-    if not (options.dummy_data_file or os.environ.get("DATABASE_URL")):
+    if (
+        not (options.dummy_data_file or os.environ.get("DATABASE_URL"))
+        and not options.validate_backend
+    ):
         parser.error(
             "error: either --dummy-data-file or DATABASE_URL environment variable is required"
         )
@@ -76,6 +85,7 @@ if options.which == "generate_cohort":
         backend_id=os.environ.get("OPENSAFELY_BACKEND"),
         dummy_data_file=options.dummy_data_file,
         temporary_database=os.environ.get("TEMP_DATABASE_NAME"),
+        validate_backend=options.validate_backend,
     )
 elif options.which == "generate_measures":
     generate_measures(

--- a/cohortextractor/__main__.py
+++ b/cohortextractor/__main__.py
@@ -2,7 +2,7 @@ import os
 from argparse import ArgumentParser
 from pathlib import Path
 
-from .main import generate_cohort, generate_measures
+from .main import generate_cohort, generate_measures, run_cohort_action, validate_cohort
 
 
 def existing_python_file(value):
@@ -44,6 +44,28 @@ generate_cohort_parser.add_argument(
     help="Validate the cohort definition against the specified backend",
 )
 
+validate_cohort_parser = subparsers.add_parser(
+    "validate_cohort",
+    help="Validate the cohort definition against the specified backend",
+)
+validate_cohort_parser.set_defaults(which="validate_cohort")
+
+validate_cohort_parser.add_argument(
+    "backend",
+    type=str,
+    choices=["tpp", "graphnet"],
+)
+validate_cohort_parser.add_argument(
+    "--cohort-definition",
+    help="The path of the file where the cohort is defined",
+    type=existing_python_file,
+)
+validate_cohort_parser.add_argument(
+    "--output",
+    help="Path and filename (or pattern) of the file(s) where the output will be written",
+    type=Path,
+)
+
 generate_measures_parser = subparsers.add_parser(
     "generate_measures", help="Generate measures from cohort data"
 )
@@ -70,22 +92,26 @@ options = parser.parse_args()
 
 
 if options.which == "generate_cohort":
-    if (
-        not (options.dummy_data_file or os.environ.get("DATABASE_URL"))
-        and not options.validate_backend
-    ):
+    if not (options.dummy_data_file or os.environ.get("DATABASE_URL")):
         parser.error(
             "error: either --dummy-data-file or DATABASE_URL environment variable is required"
         )
 
-    generate_cohort(
+    run_cohort_action(
+        generate_cohort,
         definition_path=options.cohort_definition,
         output_file=options.output,
         db_url=os.environ.get("DATABASE_URL"),
         backend_id=os.environ.get("OPENSAFELY_BACKEND"),
         dummy_data_file=options.dummy_data_file,
         temporary_database=os.environ.get("TEMP_DATABASE_NAME"),
-        validate_backend=options.validate_backend,
+    )
+elif options.which == "validate_cohort":
+    run_cohort_action(
+        validate_cohort,
+        definition_path=options.cohort_definition,
+        output_file=options.output,
+        backend_id=options.backend,
     )
 elif options.which == "generate_measures":
     generate_measures(

--- a/cohortextractor/__main__.py
+++ b/cohortextractor/__main__.py
@@ -36,13 +36,6 @@ generate_cohort_parser.add_argument(
     help="Provide dummy data from a file to be validated and used as output",
     type=Path,
 )
-generate_cohort_parser.add_argument(
-    "--validate-backend",
-    type=str,
-    nargs="?",
-    choices=["tpp", "graphnet"],
-    help="Validate the cohort definition against the specified backend",
-)
 
 validate_cohort_parser = subparsers.add_parser(
     "validate_cohort",

--- a/cohortextractor/main.py
+++ b/cohortextractor/main.py
@@ -17,44 +17,24 @@ from .validate_dummy_data import validate_dummy_data
 log = structlog.getLogger()
 
 
-def generate_cohort(
-    definition_path,
-    output_file,
-    backend_id,
-    db_url,
-    dummy_data_file=None,
-    temporary_database=None,
-    validate_backend=None,
+def run_cohort_action(
+    cohort_action_function, definition_path, output_file, **function_kwargs
 ):
-    if validate_backend:
-        log.info(f"Validating cohort for {str(definition_path)}")
-    else:
-        log.info(
-            f"Generating cohort  as {output_file}",
-        )
-    log.debug(
-        "args:",
-        definition_path=definition_path,
-        output_file=output_file,
-        backend=backend_id,
-        dummy_data_file=dummy_data_file,
-    )
+    log.info(f"Running {cohort_action_function.__name__} for {str(definition_path)}")
+    log.debug("args:", **function_kwargs)
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
     module = load_module(definition_path)
-
     cohort_class_generator, index_date_range = load_cohort_generator(module)
+    if len(index_date_range) > 1 and "*" not in output_file.name:
+        # ensure we have a replaceable pattern as an output file when multiple
+        # dates ranges are to be output
+        raise ValueError(f"No output pattern found in output file {output_file}")
 
     for index_date in index_date_range:
         if index_date is not None:
             log.info(f"Setting index_date to {index_date}")
             date_suffix = index_date
-            if len(index_date_range) > 1 and "*" not in output_file.name:
-                # ensure we have a replaceable pattern as an output file when multiple
-                # dates ranges are to be output
-                raise ValueError(
-                    f"No output pattern found in output file {output_file}"
-                )
         else:
             date_suffix = ""
 
@@ -63,31 +43,49 @@ def generate_cohort(
             if index_date
             else cohort_class_generator()
         )
-        output_file_with_date = _replace_filepath_pattern(output_file, date_suffix)
-        if validate_backend:
-            if index_date:
-                log.info("Validating for index date", index_date=index_date)
-            backend = BACKENDS[validate_backend](
-                db_url, temporary_database=temporary_database
-            )
-            results = validate(cohort, backend)
-            log.info("Validation succeeded")
-            write_validation_output(results, output_file_with_date)
+        cohort_action_function(
+            cohort, index_date, output_file, date_suffix, **function_kwargs
+        )
 
-        elif dummy_data_file and not db_url:
-            dummy_data_file_with_date = Path(
-                str(dummy_data_file).replace("*", date_suffix)
-            )
-            validate_dummy_data(
-                cohort, dummy_data_file_with_date, output_file_with_date
-            )
-            shutil.copyfile(dummy_data_file_with_date, output_file_with_date)
-        else:
-            backend = BACKENDS[backend_id](
-                db_url, temporary_database=temporary_database
-            )
-            results = extract(cohort, backend)
-            write_output(results, output_file_with_date)
+
+def generate_cohort(
+    cohort,
+    index_date,
+    output_file,
+    date_suffix,
+    backend_id,
+    db_url,
+    dummy_data_file=None,
+    temporary_database=None,
+):
+    output_file_with_date = _replace_filepath_pattern(output_file, date_suffix)
+    if index_date:
+        log.info("Generating cohort for index date", index_date=index_date)
+
+    if dummy_data_file and not db_url:
+        dummy_data_file_with_date = Path(str(dummy_data_file).replace("*", date_suffix))
+        validate_dummy_data(cohort, dummy_data_file_with_date, output_file_with_date)
+        shutil.copyfile(dummy_data_file_with_date, output_file_with_date)
+    else:
+        backend = BACKENDS[backend_id](db_url, temporary_database=temporary_database)
+        results = extract(cohort, backend)
+        write_output(results, output_file_with_date)
+
+
+def validate_cohort(
+    cohort,
+    index_date,
+    output_file,
+    date_suffix,
+    backend_id,
+):
+    output_file_with_date = _replace_filepath_pattern(output_file, date_suffix)
+    if index_date:
+        log.info("Validating for index date", index_date=index_date)
+    backend = BACKENDS[backend_id](database_url=None)
+    results = validate(cohort, backend)
+    log.info("Validation succeeded")
+    write_validation_output(results, output_file_with_date)
 
 
 def generate_measures(definition_path, input_file, output_file):

--- a/cohortextractor/query_engines/base_sql.py
+++ b/cohortextractor/query_engines/base_sql.py
@@ -319,7 +319,13 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         # every table must have a patient_id column; select it and the specified columns
         columns = sorted({"patient_id"}.union(columns))
         table_expr = self.backend.get_table_expression(base_table.name)
-        column_objs = [table_expr.c[column] for column in columns]
+        try:
+            column_objs = [table_expr.c[column] for column in columns]
+        except KeyError as unknown_key:
+            raise KeyError(
+                f"Column {unknown_key} not found in table '{base_table.name}'"
+            )
+
         query = sqlalchemy.select(column_objs).select_from(table_expr)
         return query
 

--- a/tests/backends/test_databricks.py
+++ b/tests/backends/test_databricks.py
@@ -2,11 +2,11 @@ import random
 from datetime import date
 
 import pytest
+from lib.databricks_schema import HESApc, HESApcOtr, MPSHESApc, PCareMeds
+from lib.util import extract, iter_flatten
 
 from cohortextractor import codelist, table
 from cohortextractor.backends.databricks import DatabricksBackend
-from tests.lib.databricks_schema import HESApc, HESApcOtr, MPSHESApc, PCareMeds
-from tests.lib.util import extract, iter_flatten
 
 
 # Keep things deterministic

--- a/tests/end_to_end/test_end_to_end_tpp.py
+++ b/tests/end_to_end/test_end_to_end_tpp.py
@@ -3,6 +3,8 @@ from end_to_end.utils import assert_results_equivalent
 from lib.tpp_schema import CTV3Events, Patient, RegistrationHistory
 from lib.util import mark_xfail_in_playback_mode
 
+from cohortextractor.main import validate_cohort
+
 
 @pytest.mark.smoke
 def test_extracts_data_from_sql_server_smoke_test(
@@ -45,6 +47,17 @@ def test_dummy_data(load_study, cohort_extractor_in_process_no_database):
     study = load_study("end_to_end_tests_tpp", definition_file="tpp_cohort.py")
     actual_results = cohort_extractor_in_process_no_database(study, use_dummy_data=True)
     assert_results_equivalent(actual_results, study.expected_results())
+
+
+def test_validate_cohort(load_study, cohort_extractor_in_process_no_database):
+    study = load_study("end_to_end_tests_tpp", definition_file="tpp_cohort.py")
+    actual_results = cohort_extractor_in_process_no_database(
+        study, backend="tpp", action=validate_cohort
+    )
+    # validate_cohort exceeds and outputs SQL
+    with open(actual_results) as actual_file:
+        actual_data = actual_file.readlines()
+        assert actual_data[0].startswith("SELECT * INTO")
 
 
 @mark_xfail_in_playback_mode

--- a/tests/test_validate_backend.py
+++ b/tests/test_validate_backend.py
@@ -1,0 +1,62 @@
+import pytest
+from lib.mock_backend import MockBackend
+
+from cohortextractor import table
+from cohortextractor.backends import TPPBackend
+from cohortextractor.main import validate
+
+
+def test_validate_with_error():
+    class Cohort:
+        code = table("foo").first_by("patient_id").get("code")
+
+    with pytest.raises(ValueError, match="Unknown table 'foo'"):
+        validate(Cohort, MockBackend(None))
+
+
+@pytest.mark.parametrize(
+    "backend, column, expected_succeess",
+    [
+        (MockBackend, "date_of_birth", True),
+        (MockBackend, "height", True),  # column exists in the mock backend only
+        (TPPBackend, "date_of_birth", True),
+        (TPPBackend, "height", False),
+    ],
+)
+def test_validate_for_backends(backend, column, expected_succeess):
+    class Cohort:
+        code = table("patients").first_by("patient_id").get(column)
+
+    if expected_succeess:
+        results = validate(Cohort, backend(None))
+        assert len(results) == 3
+    else:
+        with pytest.raises(
+            KeyError, match=f"Column '{column}' not found in table 'patients'"
+        ):
+            validate(Cohort, backend(None))
+
+
+def test_validate_success():
+    class Cohort:
+        code = table("clinical_events").first_by("patient_id").get("code")
+
+    results = validate(Cohort, MockBackend(None))
+
+    # when the validation succeeds, the result is a list of the generated SQL queries
+    assert len(results) == 3
+    # The first 2 queries will build the temp tables to select
+    # 1) the "code" variable from its base table (clinical_events)
+    # 2) the patients from the practice_registrations table
+    query1 = str(results[0])
+    assert query1.startswith("SELECT * INTO #group_table_0")
+    assert "SELECT clinical_events.code AS code" in query1
+    query2 = str(results[1])
+    assert query2.startswith("SELECT * INTO #group_table_1")
+    assert "SELECT practice_registrations.patient_id AS patient_id" in query2
+
+    # 3rd query selects the results from the temp tables
+    query3 = str(results[2])
+    assert query3.startswith(
+        'SELECT "#group_table_1".patient_id AS patient_id, "#group_table_0".code AS code'
+    )


### PR DESCRIPTION
This adds a `validate_cohort` command which runs the query engine's `generate_queries()` method against a specified backend, and writes the generated SQL to the output file (but doesn't run it).  If it encounters an error it gets raised and the traceback written to the log file.  

The expectation is that this will be run as an action in the project.yaml, and users will run it locally with `opensafely run ...` to validate their study definition.

This branch on the long covid study has the expected action:
https://github.com/opensafely/long-covid/blob/v2-with-validation/project.yaml#L42

Running it results in the following output:
```
➤ opensafely run validate_cohort_v2

Running actions: validate_cohort_v2

jobrunner.run loop started
validate_cohort_v2: Preparing
validate_cohort_v2: Copying in code from /home/becky/datalab/long-covid
validate_cohort_v2: Started
validate_cohort_v2: View live logs using: docker logs -f job-long-covid-validate-cohort-v2-qpuogwpqqx6ah7pj
validate_cohort_v2: Running
validate_cohort_v2: Finished, checking status and extracting outputs
validate_cohort_v2: Logs written to: /home/becky/datalab/long-covid/metadata/validate_cohort_v2.log
validate_cohort_v2: Extracting output file: output/v2/generated_sql.csv
validate_cohort_v2: Completed successfully
validate_cohort_v2: Cleaning up container and volume

=> validate_cohort_v2
   Completed successfully

   log file: metadata/validate_cohort_v2.log
   outputs:
     output/v2/generated_sql.csv  - moderately_sensitive
```

Contents of metadata/validate_cohort_v2.log:
```
2021-11-05T12:41:41.183789094Z 2021-11-05 12:41:41 [info     ] Validating cohort for analysis/study_definition_cohort_v2.py [cohortextractor.main] 
2021-11-05T12:41:41.324333106Z 2021-11-05 12:41:41 [info     ] Validation succeeded           [cohortextractor.main] 

state: succeeded
docker_image_id: sha256:22d73f8c600e54dd0c6b13b9258155615515a883c9e9a62cec95c9ac15db1ef6
job_id: qpuogwpqqx6ah7pj
run_by_user: becky
created_at: 2021-11-05T12:41:38Z
completed_at: 2021-11-05T12:41:42Z

Completed successfully

outputs:
  output/v2/generated_sql.csv  - moderately_sensitive
```

Initially, there was an error in the long covid v2 study definition, which this identified: `sex` was defined as 
```
sex = table("patients").get("sex")
```
(which selected the whole column), instead of the following, which selects the value (one row per patient)
```
sex = table("patients").first_by("patient_id").get("sex")
```

With that error, the output of running `opensafely run` is:
```
➤ opensafely run validate_cohort_v2 

Running actions: validate_cohort_v2

jobrunner.run loop started
validate_cohort_v2: Preparing
validate_cohort_v2: Copying in code from /home/becky/datalab/long-covid
validate_cohort_v2: Started
validate_cohort_v2: View live logs using: docker logs -f job-long-covid-validate-cohort-v2-j254i2iw37brx6pk
validate_cohort_v2: Running
validate_cohort_v2: Finished, checking status and extracting outputs
validate_cohort_v2: Logs written to: /home/becky/datalab/long-covid/metadata/validate_cohort_v2.log
validate_cohort_v2: Job exited with an error code
validate_cohort_v2: Cleaning up container and volume

=> validate_cohort_v2
   Job exited with an error code

   log file: metadata/validate_cohort_v2.log
   outputs:
     (no outputs)

   logs:

     2021-11-05 13:29:28 [info     ] Validating cohort for analysis/study_definition_cohort_v2.py [cohortextractor.main] 
     2021-11-05 13:29:28 [error    ] Validation failed              [cohortextractor.main] 
     Traceback (most recent call last):
       File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
         return _run_code(code, main_globals, None,
       File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
         exec(code, run_globals)
       File "/app/cohortextractor/__main__.py", line 81, in <module>
         generate_cohort(
       File "/app/cohortextractor/main.py", line 73, in generate_cohort
         results = validate(cohort, backend)
       File "/app/cohortextractor/main.py", line 208, in validate
         cohort = get_column_definitions(cohort_class)
       File "/app/cohortextractor/query_utils.py", line 16, in get_column_definitions
         raise ValueError(f"Cohort variable '{name}' is not a Value")
     ValueError: Cohort variable 'sex' is not a Value
```

and contents of of metadata/validate_cohort_v2.log:

```
2021-11-05T13:29:28.516806273Z 2021-11-05 13:29:28 [info     ] Validating cohort for analysis/study_definition_cohort_v2.py [cohortextractor.main] 
2021-11-05T13:29:28.521173450Z 2021-11-05 13:29:28 [error    ] Validation failed              [cohortextractor.main] 
2021-11-05T13:29:28.521188203Z Traceback (most recent call last):
2021-11-05T13:29:28.521191255Z   File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
2021-11-05T13:29:28.521194141Z     return _run_code(code, main_globals, None,
2021-11-05T13:29:28.521197189Z   File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
2021-11-05T13:29:28.521228632Z     exec(code, run_globals)
2021-11-05T13:29:28.521232290Z   File "/app/cohortextractor/__main__.py", line 81, in <module>
2021-11-05T13:29:28.521385484Z     generate_cohort(
2021-11-05T13:29:28.521395271Z   File "/app/cohortextractor/main.py", line 73, in generate_cohort
2021-11-05T13:29:28.521398144Z     results = validate(cohort, backend)
2021-11-05T13:29:28.521400307Z   File "/app/cohortextractor/main.py", line 208, in validate
2021-11-05T13:29:28.521402532Z     cohort = get_column_definitions(cohort_class)
2021-11-05T13:29:28.521404744Z   File "/app/cohortextractor/query_utils.py", line 16, in get_column_definitions
2021-11-05T13:29:28.521447602Z     raise ValueError(f"Cohort variable '{name}' is not a Value")
2021-11-05T13:29:28.521452778Z ValueError: Cohort variable 'sex' is not a Value


state: failed
docker_image_id: sha256:6ea6297d416658dcc242e1f8a70ecd3810d8d5989a6b4555a41b06cb614c904b
job_id: j254i2iw37brx6pk
run_by_user: becky
created_at: 2021-11-05T13:29:26Z
completed_at: 2021-11-05T13:29:29Z
exit_code: 1

Job exited with an error code

outputs:
  (no outputs)
```

This isn't a hugely helpful error message for study definition writers, so we'll also need to put some work into catching likely errors and spitting out nicer more helpful errors.