### PR TITLE
fix: databricks: support the use of db schemas

### DIFF
--- a/cohortextractor/backends/base.py
+++ b/cohortextractor/backends/base.py
@@ -64,9 +64,10 @@ class SQLTable:
 
 
 class MappedTable(SQLTable):
-    def __init__(self, source, columns):
+    def __init__(self, source, columns, schema=None):
         self.source = source
         self._columns = columns
+        self._schema = schema
 
     def learn_patient_join(self, source):
         if "patient_id" not in self._columns:
@@ -74,7 +75,9 @@ class MappedTable(SQLTable):
 
     def get_query(self):
         columns = self._make_columns()
-        query = sqlalchemy.select(columns).select_from(sqlalchemy.table(self.source))
+        query = sqlalchemy.select(columns).select_from(
+            sqlalchemy.table(self.source, schema=self._schema)
+        )
         return query
 
 

--- a/cohortextractor/backends/databricks.py
+++ b/cohortextractor/backends/databricks.py
@@ -20,14 +20,15 @@ class DatabricksBackend(BaseBackend):
         SELECT
             Person_ID AS patient_id, MAX(PatientDoB) AS date_of_birth
         FROM
-            PCAREMEDS_pcaremeds
+            PCAREMEDS.pcaremeds
         GROUP BY
             Person_ID
         """,
     )
 
     prescriptions = MappedTable(
-        source="PCAREMEDS_pcaremeds",
+        source="pcaremeds",
+        schema="PCAREMEDS",
         columns=dict(
             patient_id=Column("integer", source="Person_ID"),
             prescribed_dmd_code=Column(
@@ -75,13 +76,13 @@ class DatabricksBackend(BaseBackend):
                 apc.FAE AS episode_is_finished,
                 apc_otr.SUSSPELLID AS spell_id
             FROM
-                HES_AHAS_hes_apc_{year} AS apc
+                HES_AHAS.hes_apc_{year} AS apc
             JOIN
-                HES_AHAS_MPS_hes_apc_{year} AS mps
+                HES_AHAS_MPS.hes_apc_{year} AS mps
             ON
                 apc.EPIKEY = mps.EPIKEY
             LEFT JOIN
-                HES_AHAS_hes_apc_otr_{year} AS apc_otr
+                HES_AHAS.hes_apc_otr_{year} AS apc_otr
             ON
                 apc.EPIKEY = apc_otr.EPIKEY
             """


### PR DESCRIPTION
The PoC databricks dataset uses db schemas, so support that.

This involves referencing them with . notation from queries, and also
adding support to create the schemas as part of the test db set up.
