### PR TITLE
Add minimal new DSL

### DIFF
--- a/cohortextractor/concepts/tables.py
+++ b/cohortextractor/concepts/tables.py
@@ -1,0 +1,12 @@
+from cohortextractor.query_interface import QueryBuilder
+
+
+class ClinicalEvents(QueryBuilder):
+    code = "code"
+    date = "date"
+
+    def __init__(table_name):
+        super().__init__("clinical_events")
+
+
+clinical_events = ClinicalEvents()

--- a/cohortextractor/definition/__init__.py
+++ b/cohortextractor/definition/__init__.py
@@ -1,0 +1,8 @@
+from .definition import Cohort, pick_first_value, register
+
+
+__all__ = [
+    "Cohort",
+    "pick_first_value",
+    "register",
+]

--- a/cohortextractor/definition/base.py
+++ b/cohortextractor/definition/base.py
@@ -1,4 +1,12 @@
-from weakref import WeakSet
+class CohortRegistry:
+    def __init__(self):
+        self.cohorts = set()
+
+    def add(self, cohort):
+        self.cohorts.add(cohort)
+
+    def reset(self):
+        self.cohorts = set()
 
 
-registered_cohorts = WeakSet()
+cohort_registry = CohortRegistry()

--- a/cohortextractor/definition/base.py
+++ b/cohortextractor/definition/base.py
@@ -1,0 +1,4 @@
+from weakref import WeakSet
+
+
+registered_cohorts = WeakSet()

--- a/cohortextractor/definition/definition.py
+++ b/cohortextractor/definition/definition.py
@@ -1,0 +1,23 @@
+from .base import registered_cohorts
+
+
+class Cohort:
+    ...
+
+
+def register(cohort):
+    """
+    Compile a cohort's variables
+    cohort: A Cohort instance
+    returns: list of tuples of variable name and compiled Value
+    """
+    registered_cohorts.add(cohort)
+
+
+def pick_first_value(source_table):
+    """
+    Pick the first value by date for a single column
+    source_table: query_language.Table, the table to be reduced
+    returns: Row with one row per patient, sorted by date
+    """
+    return source_table.first_by("date")

--- a/cohortextractor/definition/definition.py
+++ b/cohortextractor/definition/definition.py
@@ -1,4 +1,4 @@
-from .base import registered_cohorts
+from .base import cohort_registry
 
 
 class Cohort:
@@ -11,7 +11,7 @@ def register(cohort):
     cohort: A Cohort instance
     returns: list of tuples of variable name and compiled Value
     """
-    registered_cohorts.add(cohort)
+    cohort_registry.add(cohort)
 
 
 def pick_first_value(source_table):

--- a/cohortextractor/main.py
+++ b/cohortextractor/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import structlog
 
 from .backends import BACKENDS
+from .definition.base import registered_cohorts
 from .measure import MeasuresManager, combine_csv_files_with_dates
 from .query_utils import get_column_definitions, get_measures
 from .validate_dummy_data import validate_dummy_data
@@ -38,11 +39,14 @@ def run_cohort_action(
         else:
             date_suffix = ""
 
-        cohort = (
-            cohort_class_generator(index_date)
-            if index_date
-            else cohort_class_generator()
-        )
+        if registered_cohorts:
+            (cohort,) = registered_cohorts
+        else:
+            cohort = (
+                cohort_class_generator(index_date)
+                if index_date
+                else cohort_class_generator()
+            )
         cohort_action_function(
             cohort, index_date, output_file, date_suffix, **function_kwargs
         )

--- a/cohortextractor/main.py
+++ b/cohortextractor/main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import structlog
 
 from .backends import BACKENDS
-from .definition.base import registered_cohorts
+from .definition.base import cohort_registry
 from .measure import MeasuresManager, combine_csv_files_with_dates
 from .query_utils import get_column_definitions, get_measures
 from .validate_dummy_data import validate_dummy_data
@@ -26,6 +26,7 @@ def run_cohort_action(
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
     module = load_module(definition_path)
+
     cohort_class_generator, index_date_range = load_cohort_generator(module)
     if len(index_date_range) > 1 and "*" not in output_file.name:
         # ensure we have a replaceable pattern as an output file when multiple
@@ -39,8 +40,12 @@ def run_cohort_action(
         else:
             date_suffix = ""
 
-        if registered_cohorts:
-            (cohort,) = registered_cohorts
+        if cohort_registry.cohorts:
+            # Currently we expect at most one cohort to be registered
+            assert (
+                len(cohort_registry.cohorts) == 1
+            ), f"At most one registered cohort is allowed, found {len(cohort_registry.cohorts)}"
+            (cohort,) = cohort_registry.cohorts
         else:
             cohort = (
                 cohort_class_generator(index_date)

--- a/cohortextractor/query_interface.py
+++ b/cohortextractor/query_interface.py
@@ -1,0 +1,33 @@
+"""The interface between the DSL and the query language (semantic model)"""
+from cohortextractor import query_language
+
+
+class QueryBuilder:
+    def __init__(self, table_name):
+        self.table_name = table_name
+
+    def select_column(self, column_name):
+        return Column(self.table_name, column_name)
+
+
+class Column:
+    def __init__(self, table_name, column_name):
+        self.table_name = table_name
+        self.column_name = column_name
+
+    def make_one_row_per_patient(self, reduce_function):
+        return Variable(self.table_name, self.column_name, reduce_function)
+
+
+class Variable:
+    def __init__(self, table_name, column_name, reduce_function):
+        self.table_name = table_name
+        self.column_name = column_name
+        self.reduce_function = reduce_function
+
+    def compile_to_query_language(self):
+        """Compile the query language Value"""
+        table = query_language.table(self.table_name)
+        patient = self.reduce_function(table)
+        column = patient.get(self.column_name)
+        return column

--- a/cohortextractor/query_utils.py
+++ b/cohortextractor/query_utils.py
@@ -1,3 +1,5 @@
+from .definition import Cohort as CohortConcept
+from .query_interface import Variable
 from .query_language import Value
 
 
@@ -6,10 +8,22 @@ def get_class_vars(cls):
     return [(key, value) for key, value in vars(cls).items() if key not in default_vars]
 
 
-def get_column_definitions(cohort_cls):
+def get_cohort_variables(cohort):
+    return [
+        (variable_name, variable.compile_to_query_language())
+        for (variable_name, variable) in vars(cohort).items()
+        if isinstance(variable, Variable)
+    ]
+
+
+def get_column_definitions(cohort_class):
+    if isinstance(cohort_class, CohortConcept):
+        variables = get_cohort_variables(cohort_class)
+    else:
+        variables = get_class_vars(cohort_class)
     columns = {}
     ignored_names = ["measures", "BASE_INDEX_DATE"]
-    for name, value in get_class_vars(cohort_cls):
+    for name, value in variables:
         if name.startswith("_") or name in ignored_names:
             continue
         if not isinstance(value, Value):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from lib.tpp_schema import Base as TppBase
 from lib.util import iter_flatten
 from sqlalchemy.orm import sessionmaker
 
+from cohortextractor.definition.base import cohort_registry
+
 
 BASES = {"tpp": TppBase, "graphnet": GraphnetBase, "databricks": DatabricksBase}
 
@@ -102,3 +104,9 @@ def setup_spark_database(spark_database):
         session.commit()
 
     return setup
+
+
+@pytest.fixture(autouse=True)
+def cleanup_register():
+    yield
+    cohort_registry.reset()

--- a/tests/end_to_end/test_end_to_end_tpp.py
+++ b/tests/end_to_end/test_end_to_end_tpp.py
@@ -19,9 +19,26 @@ def test_extracts_data_from_sql_server_integration_test(
     run_test(load_study, setup_backend_database, cohort_extractor_in_process)
 
 
-def run_test(
-    load_study, setup_backend_database, cohort_extractor, dummy_data_file=None
+@pytest.mark.integration
+def test_extracts_data_from_sql_server_integration_test_new_dsl(
+    load_study, setup_backend_database, cohort_extractor_in_process
 ):
+    run_test(
+        load_study,
+        setup_backend_database,
+        cohort_extractor_in_process,
+        definition_file="tpp_cohort_new_dsl.py",
+    )
+
+
+def run_test(
+    load_study,
+    setup_backend_database,
+    cohort_extractor,
+    definition_file=None,
+    dummy_data_file=None,
+):
+    definition_file = definition_file or "tpp_cohort.py"
     setup_backend_database(
         Patient(Patient_ID=1),
         CTV3Events(Patient_ID=1, ConsultationDate="2021-01-01", CTV3Code="xyz"),
@@ -32,7 +49,7 @@ def run_test(
     )
     study = load_study(
         "end_to_end_tests_tpp",
-        definition_file="tpp_cohort.py",
+        definition_file=definition_file,
         dummy_data_file=dummy_data_file,
     )
     actual_results = cohort_extractor(
@@ -68,5 +85,5 @@ def test_extracts_data_from_sql_server_ignores_dummy_data_file(
         load_study,
         setup_backend_database,
         cohort_extractor_in_process,
-        "invalid_dummy_data.csv",
+        dummy_data_file="invalid_dummy_data.csv",
     )

--- a/tests/fixtures/end_to_end_tests_tpp/tpp_cohort_new_dsl.py
+++ b/tests/fixtures/end_to_end_tests_tpp/tpp_cohort_new_dsl.py
@@ -1,0 +1,13 @@
+from cohortextractor.concepts import tables
+from cohortextractor.definition import Cohort, pick_first_value, register
+
+
+cohort = Cohort()
+events = tables.clinical_events
+cohort.date = events.select_column(events.date).make_one_row_per_patient(
+    pick_first_value
+)
+cohort.event = events.select_column(events.code).make_one_row_per_patient(
+    pick_first_value
+)
+register(cohort)

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,13 +1,13 @@
 from cohortextractor.concepts import tables
 from cohortextractor.definition import Cohort, pick_first_value, register
-from cohortextractor.definition.base import registered_cohorts
+from cohortextractor.definition.base import cohort_registry
 from cohortextractor.query_language import table
 from cohortextractor.query_utils import get_column_definitions
 
 
 def test_minimal_cohort_definition():
     # Nothing in the registry yet
-    assert not registered_cohorts
+    assert not cohort_registry.cohorts
 
     # old DSL
     class OldCohort:
@@ -22,8 +22,8 @@ def test_minimal_cohort_definition():
     )
     register(cohort)
 
-    assert cohort in registered_cohorts
-    (registered_cohort,) = registered_cohorts
+    assert cohort in cohort_registry.cohorts
+    (registered_cohort,) = cohort_registry.cohorts
     assert get_column_definitions(registered_cohort) == get_column_definitions(
         OldCohort
     )

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,0 +1,29 @@
+from cohortextractor.concepts import tables
+from cohortextractor.definition import Cohort, pick_first_value, register
+from cohortextractor.definition.base import registered_cohorts
+from cohortextractor.query_language import table
+from cohortextractor.query_utils import get_column_definitions
+
+
+def test_minimal_cohort_definition():
+    # Nothing in the registry yet
+    assert not registered_cohorts
+
+    # old DSL
+    class OldCohort:
+        #  Define tables of interest, filtered to relevant values
+        code = table("clinical_events").first_by("date").get("code")
+
+    # new DSL
+    cohort = Cohort()
+    events = tables.clinical_events
+    cohort.code = events.select_column(events.code).make_one_row_per_patient(
+        pick_first_value
+    )
+    register(cohort)
+
+    assert cohort in registered_cohorts
+    (registered_cohort,) = registered_cohorts
+    assert get_column_definitions(registered_cohort) == get_column_definitions(
+        OldCohort
+    )


### PR DESCRIPTION
Implements the minimal cohort definition defined in https://app.shortcut.com/ebm-datalab/story/62/minimal-introduction-of-new-dsl and tests that it produces the same query language graph as the equivalent old-style cohort definition.

`query_interface.py` is intended to hold the things that translate the new DSL to the query_language.

The second commit adds a minimal end-to-end test, which was mainly for my benefit to check that the cohort registration worked - it adds a  small amount of code to `main.py` so it may be beyond the scope of this ticket, and can be removed if it's in the way.

