### PR TITLE
Set `fail-under=0` for interrogate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,6 @@ repos:
     - id: isort
       language_version: python3.9
 
-  - repo: https://github.com/econchick/interrogate
-    rev: 1.4.0
-    hooks:
-    - id: interrogate
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ exclude_lines = [
 [tool.coverage.html]
 
 [tool.interrogate]
-fail-under = 26
+fail-under = 0
 ignore-init-module = true
 omit-covered-files = true
 verbose = 1


### PR DESCRIPTION
This is a temporary measure. Adding docstrings, particularly to the
domain specific language parts of the code, is a task to be completed
fairly soon, but not yet started.

For now, allow this check to run, but always pass. This avoids
inconveniencing developers who are doing other things right now. We
should enforce this again once docstrings are added to the relevant
parts of the code.