### PR TITLE
fix: use macOS compatible database port

### DIFF
--- a/tests/lib/databases.py
+++ b/tests/lib/databases.py
@@ -101,7 +101,7 @@ def wait_for_database(database, timeout=10):
             time.sleep(1)
 
 
-PERSISTENT_DATABASE_PORT = 49152
+PERSISTENT_DATABASE_PORT = 49151
 
 
 def run_mssql(


### PR DESCRIPTION
* tests were failing in unhelpful ways on macOS when there are AirPlay devices on the same network, this appears to be because 49152 is already somewhat in use