### PR TITLE
Add minimal backend "concepts"

### DIFF
--- a/cohortextractor/backends/base.py
+++ b/cohortextractor/backends/base.py
@@ -30,6 +30,11 @@ class BaseBackend:
                 cls.tables.add(name)
                 value.learn_patient_join(cls.patient_join_column)
                 value.learn_type_map(cls.query_engine_class.type_map)
+                # Validate that the table correctly implements the contract it claims
+                # to, if any
+                contract = value.implements
+                if contract:
+                    contract.validate_implementation(cls, name, value)
 
     def __init__(self, database_url, temporary_database=None):
         self.database_url = database_url

--- a/cohortextractor/backends/base.py
+++ b/cohortextractor/backends/base.py
@@ -27,14 +27,17 @@ class BaseBackend:
         cls.tables = set()
         for name, value in vars(cls).items():
             if isinstance(value, SQLTable):
+                cls._init_table(name, value)
                 cls.tables.add(name)
-                value.learn_patient_join(cls.patient_join_column)
-                value.learn_type_map(cls.query_engine_class.type_map)
-                # Validate that the table correctly implements the contract it claims
-                # to, if any
-                contract = value.implements
-                if contract:
-                    contract.validate_implementation(cls, name, value)
+
+    @classmethod
+    def _init_table(cls, name, table):
+        table.learn_patient_join(cls.patient_join_column)
+        table.learn_type_map(cls.query_engine_class.type_map)
+        # Validate that the table correctly implements the contract it claims to, if any
+        contract = table.implements
+        if contract:
+            contract.validate_implementation(cls, name, table)
 
     def __init__(self, database_url, temporary_database=None):
         self.database_url = database_url

--- a/cohortextractor/backends/base.py
+++ b/cohortextractor/backends/base.py
@@ -51,7 +51,7 @@ class SQLTable:
 
     def _make_columns(self):
         return [
-            self._make_column(name, column) for name, column in self._columns.items()
+            self._make_column(name, column) for name, column in self.columns.items()
         ]
 
     def _make_column(self, name, column):
@@ -64,14 +64,15 @@ class SQLTable:
 
 
 class MappedTable(SQLTable):
-    def __init__(self, source, columns, schema=None):
+    def __init__(self, source, columns, schema=None, implements=None):
         self.source = source
-        self._columns = columns
+        self.columns = columns
         self._schema = schema
+        self.implements = implements
 
     def learn_patient_join(self, source):
-        if "patient_id" not in self._columns:
-            self._columns["patient_id"] = Column("integer", source)
+        if "patient_id" not in self.columns:
+            self.columns["patient_id"] = Column("integer", source)
 
     def get_query(self):
         columns = self._make_columns()
@@ -82,13 +83,14 @@ class MappedTable(SQLTable):
 
 
 class QueryTable(SQLTable):
-    def __init__(self, query, columns):
+    def __init__(self, query, columns, implements=None):
         self.query = query
-        self._columns = columns
+        self.columns = columns
+        self.implements = implements
 
     def learn_patient_join(self, source):
-        if "patient_id" not in self._columns:
-            self._columns["patient_id"] = Column("integer")
+        if "patient_id" not in self.columns:
+            self.columns["patient_id"] = Column("integer")
 
     def get_query(self):
         columns = self._make_columns()

--- a/cohortextractor/backends/tpp.py
+++ b/cohortextractor/backends/tpp.py
@@ -1,4 +1,5 @@
 from cohortextractor.backends.base import BaseBackend, Column, MappedTable, QueryTable
+from cohortextractor.concepts import tables
 from cohortextractor.query_engines.mssql import MssqlQueryEngine
 
 
@@ -58,6 +59,7 @@ class TPPBackend(BaseBackend):
     patient_join_column = "Patient_ID"
 
     patients = MappedTable(
+        implements=tables.Patients,
         source="Patient",
         columns=dict(
             sex=Column("varchar", source="Sex"),

--- a/cohortextractor/concepts/table_contract.py
+++ b/cohortextractor/concepts/table_contract.py
@@ -1,0 +1,35 @@
+import dataclasses
+
+from cohortextractor.concepts.types import BaseType
+
+
+@dataclasses.dataclass
+class Column:
+
+    type: BaseType  # noqa: A003
+    help: str  # noqa: A003
+
+
+class BackendContractError(Exception):
+    pass
+
+
+class TableContract:
+
+    columns = None
+
+    def __init_subclass__(cls, **kwargs):
+        cls.columns = {}
+        for key, value in vars(cls).items():
+            if isinstance(value, Column):
+                cls.columns[key] = value
+
+    @classmethod
+    def validate_implementation(cls, backend, table_name, table):
+        missing_columns = set(cls.columns) - set(table.columns)
+        if missing_columns:
+            raise BackendContractError(
+                f"\n'{backend.__name__}.{table_name}' does not correctly implement the"
+                f" contract for '{cls.__name__}'\n\n"
+                f"Missing columns: {', '.join(missing_columns)}"
+            )

--- a/cohortextractor/concepts/tables.py
+++ b/cohortextractor/concepts/tables.py
@@ -1,5 +1,8 @@
 from cohortextractor.query_interface import QueryBuilder
 
+from . import types
+from .table_contract import Column, TableContract
+
 
 class ClinicalEvents(QueryBuilder):
     code = "code"
@@ -10,3 +13,25 @@ class ClinicalEvents(QueryBuilder):
 
 
 clinical_events = ClinicalEvents()
+
+
+class Patients(TableContract):
+    """
+    The Patients table holds personal details about the patient.
+    """
+
+    patient_id = Column(
+        type=types.PseudoPatientId(),
+        help=(
+            "Patient's pseudonymous identifier, for linkage. You should not normally "
+            "output or operate on this column"
+        ),
+    )
+    date_of_birth = Column(
+        type=types.Date(),
+        help="The patient's date of birth",
+    )
+    sex = Column(
+        type=types.Choice("F", "M"),
+        help="The patient's sex",
+    )

--- a/cohortextractor/concepts/types.py
+++ b/cohortextractor/concepts/types.py
@@ -1,0 +1,15 @@
+class BaseType:
+    pass
+
+
+class PseudoPatientId(BaseType):
+    pass
+
+
+class Date(BaseType):
+    pass
+
+
+class Choice:
+    def __init__(self, *choices):
+        self.choices = choices

--- a/cohortextractor/query_engines/base_sql.py
+++ b/cohortextractor/query_engines/base_sql.py
@@ -67,6 +67,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     sqlalchemy_dialect = NotImplemented
 
     custom_types = {}
+    type_map = None
 
     # No limit by default although some DBMSs may impose one
     max_rows_per_insert = None

--- a/tests/concepts/test_table_contract.py
+++ b/tests/concepts/test_table_contract.py
@@ -1,0 +1,49 @@
+import pytest
+
+from cohortextractor.backends.base import BaseBackend, Column, MappedTable
+from cohortextractor.concepts import types
+from cohortextractor.concepts.table_contract import BackendContractError
+from cohortextractor.concepts.table_contract import Column as ColumnContract
+from cohortextractor.concepts.table_contract import TableContract
+from cohortextractor.query_engines.base_sql import BaseSQLQueryEngine
+
+
+def test_basic_validation_that_table_implements_patients_contract():
+    # Basic table contract
+    class PatientsContract(TableContract):
+        patient_id = ColumnContract(type=types.PseudoPatientId(), help="")
+        date_of_birth = ColumnContract(type=types.Date(), help="")
+        sex = ColumnContract(type=types.Choice("F", "M"), help="")
+
+    # Unhappy path
+    with pytest.raises(BackendContractError, match="Missing columns: sex"):
+
+        class BadBackend(BaseBackend):
+            backend_id = "bad_test_backend"
+            query_engine_class = BaseSQLQueryEngine
+            patient_join_column = "patient_id"
+
+            patients = MappedTable(
+                implements=PatientsContract,
+                source="Patient",
+                columns=dict(
+                    date_of_birth=Column("date", source="DateOfBirth"),
+                ),
+            )
+
+    # Happy path
+    class GoodBackend(BaseBackend):
+        backend_id = "good_test_backend"
+        query_engine_class = BaseSQLQueryEngine
+        patient_join_column = "patient_id"
+
+        patients = MappedTable(
+            implements=PatientsContract,
+            source="Patient",
+            columns=dict(
+                date_of_birth=Column("date", source="DateOfBirth"),
+                sex=Column("varchar", source="Sex"),
+            ),
+        )
+
+    assert GoodBackend("db://")


### PR DESCRIPTION
Add basic walking skeleton code which allows tables to declare that they implement certain "concepts" i.e. they have a certain set of tables and those tables have a certain type. This also involves the assertion that those columns have a certain _meaning_ in the context of clinical research and can play approximately the same role across other backends which share that "concept". But of course we can't enforce that programmatically.

You'll note the word "contract" has slipped into the codebase here. I seem to remember the word floating around in earlier discussions and it seemed a natural way of characterising the assertion being made here.

In contrast to the initial pseudocode I've made the `implements` declaration be part of the table definition, rather than a method call we make somewhere else as it seemed more natural to keep the two together. It's easy enough to change if there's some other reason we'd like to keep them separate though.

**Note**: this doesn't yet do any rudimentary documentation generation because, although that's part of the below story, I felt it was better tackled in a separate PR.

Relates to:
[sc-39]
https://app.shortcut.com/ebm-datalab/story/39/minimal-end-to-end-backend-definition