### PR TITLE
Add mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,18 @@ repos:
     - id: isort
       language_version: python3.9
 
-
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.29.0
     hooks:
     -   id: pyupgrade
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+    - id: mypy
+      language_version: python3.9
+      additional_dependencies:
+       - "sqlalchemy-stubs"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/Justfile
+++ b/Justfile
@@ -95,6 +95,7 @@ check: devenv
     $BIN/pyupgrade --py39-plus --keep-percent-format \
         $(find cohortextractor -name "*.py" -type f) \
         $(find tests -name "*.py" -type f)
+    $BIN/mypy
 
 
 # runs the format (black) and sort (isort) checks and fixes the files

--- a/cohortextractor/backends/base.py
+++ b/cohortextractor/backends/base.py
@@ -1,5 +1,7 @@
 import sqlalchemy
 
+from ..query_engines.base_sql import BaseSQLQueryEngine
+
 
 # Mutable global for storing registered backends
 BACKENDS = {}
@@ -10,16 +12,16 @@ def register_backend(backend_class):
 
 
 class BaseBackend:
-    backend_id = NotImplemented
-    query_engine_class = NotImplemented
-    patient_join_column = NotImplemented
+    backend_id: str
+    query_engine_class: type[BaseSQLQueryEngine]
+    patient_join_column: str
 
     tables = None
 
     def __init_subclass__(cls, **kwargs):
-        assert cls.backend_id != NotImplemented
-        assert cls.query_engine_class != NotImplemented
-        assert cls.patient_join_column != NotImplemented
+        assert cls.backend_id is not None
+        assert cls.query_engine_class is not None
+        assert cls.patient_join_column is not None
 
         # Register each Backend by its id so we can identify it from an environment variable
         register_backend(cls)

--- a/cohortextractor/concepts/types.py
+++ b/cohortextractor/concepts/types.py
@@ -10,6 +10,6 @@ class Date(BaseType):
     pass
 
 
-class Choice:
+class Choice(BaseType):
     def __init__(self, *choices):
         self.choices = choices

--- a/cohortextractor/query_engines/base_sql.py
+++ b/cohortextractor/query_engines/base_sql.py
@@ -1,7 +1,7 @@
 import contextlib
 from collections import defaultdict
 from types import ModuleType
-from typing import Union
+from typing import Optional, Union
 
 import sqlalchemy
 import sqlalchemy.dialects.mssql
@@ -73,7 +73,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
     type_map = None
 
     # No limit by default although some DBMSs may impose one
-    max_rows_per_insert = None
+    max_rows_per_insert: Optional[int] = None
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/cohortextractor/query_engines/base_sql.py
+++ b/cohortextractor/query_engines/base_sql.py
@@ -69,7 +69,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     sqlalchemy_dialect: Union[type[Dialect], ModuleType]
 
-    custom_types = {}
+    custom_types: dict[str, type[sqlalchemy.types.TypeDecorator]] = {}
     type_map = None
 
     # No limit by default although some DBMSs may impose one

--- a/cohortextractor/query_engines/base_sql.py
+++ b/cohortextractor/query_engines/base_sql.py
@@ -1,10 +1,13 @@
 import contextlib
 from collections import defaultdict
+from types import ModuleType
+from typing import Union
 
 import sqlalchemy
 import sqlalchemy.dialects.mssql
 import sqlalchemy.schema
 import sqlalchemy.types
+from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql.expression import type_coerce
 
 from ..query_language import (
@@ -64,7 +67,7 @@ def get_primary_table(query):
 
 class BaseSQLQueryEngine(BaseQueryEngine):
 
-    sqlalchemy_dialect = NotImplemented
+    sqlalchemy_dialect: Union[type[Dialect], ModuleType]
 
     custom_types = {}
     type_map = None
@@ -74,7 +77,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        assert cls.sqlalchemy_dialect != NotImplemented
+        assert cls.sqlalchemy_dialect is not None
         cls.type_map = {**DEFAULT_TYPES, **cls.custom_types}
 
     def __init__(self, column_definitions, backend):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,41 @@ multi_line_output = 3
 skip_glob = [".direnv", "venv", ".venv"]
 use_parentheses = true
 
+[tool.mypy]
+files = "cohortextractor"
+plugins = [
+  "sqlmypy",
+]
+
+# Consider turning on these stricter options later.  They require a
+# significantly larger number of changes to the codebase so we have decided to
+# work towards them.
+# check_untyped_defs = true
+# disallow_untyped_calls = true
+# disallow_untyped_decorators = true
+# disallow_untyped_defs = true
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_incomplete_defs
+disallow_incomplete_defs = true
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-no_implicit_optional
+no_implicit_optional = true
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_redundant_casts
+warn_redundant_casts = true
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_unused_ignores
+warn_unused_ignores = true
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_unreachable
+warn_unreachable = true
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-scripts_are_modules
+scripts_are_modules = true
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-show_error_codes
+show_error_codes = true
+
 [tool.pytest.ini_options]
 addopts = "--tb=native --strict-markers"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ scripts_are_modules = true
 # https://mypy.readthedocs.io/en/stable/config_file.html#confval-show_error_codes
 show_error_codes = true
 
+[[tool.mypy.overrides]]
+module = "pyhive.sqlalchemy_hive.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 addopts = "--tb=native --strict-markers"
 markers = [

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -12,10 +12,13 @@ flake8-implicit-str-concat
 flake8-no-pep420
 interrogate
 isort
+mypy
+pandas-stubs
 pytest
 pytest-cov
 pytest-freezegun
 pytest-mock
 pyupgrade
+sqlalchemy-stubs
 docker
 six # undeclared dependency of docker (https://github.com/docker/docker-py/issues/2842)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -139,10 +139,39 @@ more-itertools==8.10.0 \
     --hash=sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f \
     --hash=sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43
     # via flake8-implicit-str-concat
+mypy==0.910 \
+    --hash=sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9 \
+    --hash=sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a \
+    --hash=sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9 \
+    --hash=sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e \
+    --hash=sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2 \
+    --hash=sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212 \
+    --hash=sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b \
+    --hash=sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885 \
+    --hash=sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150 \
+    --hash=sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703 \
+    --hash=sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072 \
+    --hash=sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457 \
+    --hash=sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e \
+    --hash=sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0 \
+    --hash=sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb \
+    --hash=sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97 \
+    --hash=sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8 \
+    --hash=sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811 \
+    --hash=sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6 \
+    --hash=sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de \
+    --hash=sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504 \
+    --hash=sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921 \
+    --hash=sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d
+    # via
+    #   -r requirements.dev.in
+    #   sqlalchemy-stubs
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
-    # via black
+    # via
+    #   black
+    #   mypy
 nodeenv==1.6.0 \
     --hash=sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b \
     --hash=sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7
@@ -151,6 +180,10 @@ packaging==21.0 \
     --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7 \
     --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14
     # via pytest
+pandas-stubs==1.2.0.37 \
+    --hash=sha256:48218405dfdd59fc96a4ce5383a28b59ed969aa010cfa621c725a2b1c7d200a6 \
+    --hash=sha256:da75cf6aa26ba506733e7f2be340b791acccb5daa108f59a030bf5079159eecc
+    # via -r requirements.dev.in
 pathspec==0.9.0 \
     --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
     --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
@@ -303,6 +336,10 @@ six==1.16.0 \
     #   -r requirements.dev.in
     #   python-dateutil
     #   virtualenv
+sqlalchemy-stubs==0.4 \
+    --hash=sha256:5eec7aa110adf9b957b631799a72fef396b23ff99fe296df726645d01e312aa5 \
+    --hash=sha256:c665d6dd4482ef642f01027fa06c3d5e91befabb219dc71fc2a09e7d7695f7ae
+    # via -r requirements.dev.in
 tabulate==0.8.9 \
     --hash=sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4 \
     --hash=sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7
@@ -316,6 +353,7 @@ toml==0.10.2 \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via
     #   interrogate
+    #   mypy
     #   pre-commit
     #   pytest
 tomli==1.2.1 \
@@ -328,7 +366,10 @@ typing-extensions==3.10.0.2 \
     --hash=sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e \
     --hash=sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7 \
     --hash=sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34
-    # via black
+    # via
+    #   black
+    #   mypy
+    #   sqlalchemy-stubs
 urllib3==1.26.7 \
     --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
     --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844


### PR DESCRIPTION
This adds mypy, with some settings which looked useful, verbosely linked to the docs because we don't have a lot of team knowledge around the tool yet.

Mypy seems to be quite permissive by default and there are many settings we can turn on to add further strictness.  I've opted for the defaults with a few extra checks to start with.  But I'd like to aim for getting the following added over time: 

* [check_untyped_defs](https://mypy.readthedocs.io/en/stable/config_file.html#confval-check_untyped_defs)
* [disallow_untyped_calls](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_untyped_calls)
* [disallow_untyped_decorators](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_untyped_decorators)
* [disallow_untyped_defs](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_untyped_defs)
