### PR TITLE
Make test setup a method on database fixture

### DIFF
--- a/tests/acceptance/test_full_long_covid_study.py
+++ b/tests/acceptance/test_full_long_covid_study.py
@@ -151,8 +151,8 @@ for target_codelist in [any_long_covid_code, post_viral_fatigue_codes]:
 
 
 @pytest.mark.integration
-def test_cohort(database, setup_test_database):
-    setup_test_database(
+def test_cohort(database):
+    database.setup(
         organisation(organisation_id=1, region="South"),
         patient(
             1,

--- a/tests/acceptance/test_simplified_long_covid_study.py
+++ b/tests/acceptance/test_simplified_long_covid_study.py
@@ -83,8 +83,8 @@ for code in long_covid_diagnostic_codes.codes:
 
 
 @pytest.mark.integration
-def test_simplified_cohort(database, setup_test_database):
-    setup_test_database(
+def test_simplified_cohort(database):
+    database.setup(
         patient(
             1,
             "F",

--- a/tests/acceptance/test_sro_measures_study.py
+++ b/tests/acceptance/test_sro_measures_study.py
@@ -99,8 +99,8 @@ def cohort(index_date, backend):
 
 
 @pytest.mark.integration
-def test_cohort_tpp_backend(database, setup_test_database):
-    setup_test_database(
+def test_cohort_tpp_backend(database):
+    database.setup(
         tpp_schema.organisation(organisation_id=1, region="South"),
         tpp_schema.organisation(organisation_id=2, region="North"),
         # present at index date 1
@@ -160,8 +160,8 @@ def test_cohort_tpp_backend(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_cohort_graphnet_backend(database, setup_test_database):
-    setup_test_database(
+def test_cohort_graphnet_backend(database):
+    database.setup(
         # present at index date 1
         graphnet_schema.patient(
             1,

--- a/tests/backends/test_databricks.py
+++ b/tests/backends/test_databricks.py
@@ -55,8 +55,8 @@ def admission(
 
 
 @pytest.mark.integration
-def test_basic_databricks_study_definition(spark_database, setup_spark_database):
-    setup_spark_database(
+def test_basic_databricks_study_definition(spark_database):
+    spark_database.setup(
         patient(
             10,
             "1950-08-20",

--- a/tests/backends/test_graphnet.py
+++ b/tests/backends/test_graphnet.py
@@ -19,8 +19,8 @@ from ..lib.util import extract
 
 
 @pytest.mark.integration
-def test_basic_events_and_registration(database, setup_test_database):
-    setup_test_database(
+def test_basic_events_and_registration(database):
+    database.setup(
         Patients(Patient_ID=1),
         PracticeRegistrations(Patient_ID=1),
         ClinicalEvents(Patient_ID=1, Code="Code1", CodingSystem="CTV3"),
@@ -36,8 +36,8 @@ def test_basic_events_and_registration(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_registration_dates(database, setup_test_database):
-    setup_test_database(
+def test_registration_dates(database):
+    database.setup(
         Patients(Patient_ID=1),
         PracticeRegistrations(
             Patient_ID=1, StartDate="2001-01-01", EndDate="2012-12-12"
@@ -56,8 +56,8 @@ def test_registration_dates(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_registration_dates_no_end(database, setup_test_database):
-    setup_test_database(
+def test_registration_dates_no_end(database):
+    database.setup(
         Patients(Patient_ID=1),
         PracticeRegistrations(
             Patient_ID=1, StartDate="2011-01-01", EndDate="2012-12-31"
@@ -80,8 +80,8 @@ def test_registration_dates_no_end(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_covid_test_positive_result(database, setup_test_database):
-    setup_test_database(
+def test_covid_test_positive_result(database):
+    database.setup(
         Patients(Patient_ID=1),
         PracticeRegistrations(
             Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"
@@ -107,8 +107,8 @@ def test_covid_test_positive_result(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_covid_test_negative_result(database, setup_test_database):
-    setup_test_database(
+def test_covid_test_negative_result(database):
+    database.setup(
         Patients(Patient_ID=1),
         PracticeRegistrations(
             Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"
@@ -134,8 +134,8 @@ def test_covid_test_negative_result(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_patients_table(database, setup_test_database):
-    setup_test_database(
+def test_patients_table(database):
+    database.setup(
         Patients(Patient_ID=1, Sex="F", DateOfBirth="1950-01-01"),
         PracticeRegistrations(
             Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"
@@ -153,10 +153,8 @@ def test_patients_table(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_hospitalization_table_returns_admission_date_and_code(
-    database, setup_test_database
-):
-    setup_test_database(
+def test_hospitalization_table_returns_admission_date_and_code(database):
+    database.setup(
         patient(
             1,
             "M",
@@ -177,8 +175,8 @@ def test_hospitalization_table_returns_admission_date_and_code(
 
 
 @pytest.mark.integration
-def test_events_with_numeric_value(database, setup_test_database):
-    setup_test_database(
+def test_events_with_numeric_value(database):
+    database.setup(
         Patients(Patient_ID=1),
         PracticeRegistrations(Patient_ID=1),
         ClinicalEvents(
@@ -195,8 +193,8 @@ def test_events_with_numeric_value(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_organisation(database, setup_test_database):
-    setup_test_database(
+def test_organisation(database):
+    database.setup(
         # Organisation not a separate table, so will just move detail to single registration record
         # organisation(1, "South"),
         # organisation(2, "North"),
@@ -226,8 +224,8 @@ def test_organisation(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_organisation_dates(database, setup_test_database):
-    setup_test_database(
+def test_organisation_dates(database):
+    database.setup(
         # Organisation not a separate table, so will just move detail to registration record
         # organisation(1, "South"),
         # organisation(2, "North"),
@@ -272,8 +270,8 @@ def test_organisation_dates(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_index_of_multiple_deprivation(database, setup_test_database):
-    setup_test_database(
+def test_index_of_multiple_deprivation(database):
+    database.setup(
         patient(
             1,
             "M",
@@ -336,10 +334,8 @@ def test_index_of_multiple_deprivation(database, setup_test_database):
         ),
     ],
 )
-def test_index_of_multiple_deprivation_sorting(
-    database, setup_test_database, patient_addresses, expected
-):
-    setup_test_database(
+def test_index_of_multiple_deprivation_sorting(database, patient_addresses, expected):
+    database.setup(
         patient(
             1,
             "M",

--- a/tests/backends/test_tpp.py
+++ b/tests/backends/test_tpp.py
@@ -22,8 +22,8 @@ from ..lib.util import extract
 
 
 @pytest.mark.integration
-def test_basic_events_and_registration(database, setup_test_database):
-    setup_test_database(
+def test_basic_events_and_registration(database):
+    database.setup(
         Patient(Patient_ID=1),
         RegistrationHistory(Patient_ID=1),
         CTV3Events(Patient_ID=1, CTV3Code="Code1"),
@@ -36,8 +36,8 @@ def test_basic_events_and_registration(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_registration_dates(database, setup_test_database):
-    setup_test_database(
+def test_registration_dates(database):
+    database.setup(
         Patient(Patient_ID=1),
         RegistrationHistory(Patient_ID=1, StartDate="2001-01-01", EndDate="2012-12-12"),
     )
@@ -53,8 +53,8 @@ def test_registration_dates(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_covid_test_positive_result(database, setup_test_database):
-    setup_test_database(
+def test_covid_test_positive_result(database):
+    database.setup(
         Patient(Patient_ID=1),
         RegistrationHistory(Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"),
         SGSSPositiveTests(
@@ -75,8 +75,8 @@ def test_covid_test_positive_result(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_covid_test_negative_result(database, setup_test_database):
-    setup_test_database(
+def test_covid_test_negative_result(database):
+    database.setup(
         Patient(Patient_ID=1),
         RegistrationHistory(Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"),
         SGSSNegativeTests(
@@ -100,8 +100,8 @@ def test_covid_test_negative_result(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_patients_table(database, setup_test_database):
-    setup_test_database(
+def test_patients_table(database):
+    database.setup(
         Patient(Patient_ID=1, Sex="F", DateOfBirth="1950-01-01"),
         RegistrationHistory(Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"),
     )
@@ -117,10 +117,8 @@ def test_patients_table(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_hospitalization_table_returns_admission_date_and_code(
-    database, setup_test_database
-):
-    setup_test_database(
+def test_hospitalization_table_returns_admission_date_and_code(database):
+    database.setup(
         patient(
             1,
             "M",
@@ -158,10 +156,8 @@ def test_hospitalization_table_returns_admission_date_and_code(
     ],
 )
 @pytest.mark.integration
-def test_hospitalization_table_code_conversion(
-    database, setup_test_database, raw, codes
-):
-    setup_test_database(
+def test_hospitalization_table_code_conversion(database, raw, codes):
+    database.setup(
         patient(
             1,
             "M",
@@ -188,8 +184,8 @@ def run_query(database, query):
 
 
 @pytest.mark.integration
-def test_hospitalization_code_parsing_works_with_filters(database, setup_test_database):
-    setup_test_database(
+def test_hospitalization_code_parsing_works_with_filters(database):
+    database.setup(
         patient(
             1,
             "X",
@@ -221,8 +217,8 @@ def test_hospitalization_code_parsing_works_with_filters(database, setup_test_da
 
 
 @pytest.mark.integration
-def test_events_with_numeric_value(database, setup_test_database):
-    setup_test_database(
+def test_events_with_numeric_value(database):
+    database.setup(
         Patient(Patient_ID=1),
         RegistrationHistory(Patient_ID=1),
         CTV3Events(Patient_ID=1, CTV3Code="Code1", NumericValue=34.7),
@@ -235,8 +231,8 @@ def test_events_with_numeric_value(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_organisation(database, setup_test_database):
-    setup_test_database(
+def test_organisation(database):
+    database.setup(
         organisation(1, "South"),
         organisation(2, "North"),
         patient(1, "M", "1990-1-1", registration("2001-01-01", "2021-06-26", 1)),
@@ -255,8 +251,8 @@ def test_organisation(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_organisation_dates(database, setup_test_database):
-    setup_test_database(
+def test_organisation_dates(database):
+    database.setup(
         organisation(1, "South"),
         organisation(2, "North"),
         organisation(3, "West"),
@@ -295,8 +291,8 @@ def test_organisation_dates(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_index_of_multiple_deprivation(database, setup_test_database):
-    setup_test_database(
+def test_index_of_multiple_deprivation(database):
+    database.setup(
         patient(
             1,
             "M",
@@ -351,10 +347,8 @@ def test_index_of_multiple_deprivation(database, setup_test_database):
         ),
     ],
 )
-def test_index_of_multiple_deprivation_sorting(
-    database, setup_test_database, patient_addresses, expected
-):
-    setup_test_database(
+def test_index_of_multiple_deprivation_sorting(database, patient_addresses, expected):
+    database.setup(
         patient(
             1,
             "M",
@@ -371,8 +365,8 @@ def test_index_of_multiple_deprivation_sorting(
 
 
 @pytest.mark.integration
-def test_clinical_events_table(database, setup_test_database):
-    setup_test_database(
+def test_clinical_events_table(database):
+    database.setup(
         Patient(Patient_ID=1),
         RegistrationHistory(Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"),
         CTV3Events(Patient_ID=1, CTV3Code="Code1", ConsultationDate="2021-01-01"),
@@ -398,8 +392,8 @@ def test_clinical_events_table(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_clinical_events_table_multiple_codes(database, setup_test_database):
-    setup_test_database(
+def test_clinical_events_table_multiple_codes(database):
+    database.setup(
         Patient(Patient_ID=1),
         RegistrationHistory(Patient_ID=1, StartDate="2001-01-01", EndDate="2026-06-26"),
         CTV3Events(Patient_ID=1, CTV3Code="Code1", ConsultationDate="2021-01-01"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,20 +26,10 @@ def database(request, containers):
 
 
 @pytest.fixture(scope="session")
-def setup_test_database(database):
-    return database.setup
-
-
-@pytest.fixture(scope="session")
 def spark_database(containers):
     database = make_spark_database(containers)
     wait_for_database(database, timeout=15)
     yield database
-
-
-@pytest.fixture(scope="session")
-def setup_spark_database(spark_database):
-    return spark_database.setup
 
 
 @pytest.fixture(autouse=True)

--- a/tests/end_to_end/test_end_to_end_graphnet.py
+++ b/tests/end_to_end/test_end_to_end_graphnet.py
@@ -6,20 +6,20 @@ from .utils import assert_results_equivalent
 
 @pytest.mark.smoke
 def test_extracts_data_from_sql_server_smoke_test(
-    load_study, setup_test_database, cohort_extractor_in_container
+    load_study, database, cohort_extractor_in_container
 ):
-    run_test(load_study, setup_test_database, cohort_extractor_in_container)
+    run_test(load_study, database, cohort_extractor_in_container)
 
 
 @pytest.mark.integration
 def test_extracts_data_from_sql_server_integration_test(
-    load_study, setup_test_database, cohort_extractor_in_process
+    load_study, database, cohort_extractor_in_process
 ):
-    run_test(load_study, setup_test_database, cohort_extractor_in_process)
+    run_test(load_study, database, cohort_extractor_in_process)
 
 
-def run_test(load_study, setup_test_database, cohort_extractor, dummy_data_file=None):
-    setup_test_database(
+def run_test(load_study, database, cohort_extractor, dummy_data_file=None):
+    database.setup(
         Patients(Patient_ID=1, DateOfBirth="1980-01-01"),
         ClinicalEvents(
             Patient_ID=1, ConsultationDate="2021-01-01", Code="xyz", CodingSystem="CTV3"
@@ -53,13 +53,13 @@ def test_dummy_data(load_study, cohort_extractor_in_process_no_database):
 
 @pytest.mark.integration
 def test_extracts_data_from_sql_server_ignores_dummy_data_file(
-    load_study, setup_test_database, cohort_extractor_in_process
+    load_study, database, cohort_extractor_in_process
 ):
     # A dummy data file is ignored if running in a real backend (i.e. DATABASE_URL is set)
     # This provides an invalid dummy data file, but it is ignored so no errors are raised
     run_test(
         load_study,
-        setup_test_database,
+        database,
         cohort_extractor_in_process,
         "invalid_dummy_data.csv",
     )

--- a/tests/end_to_end/test_end_to_end_index_date_range.py
+++ b/tests/end_to_end/test_end_to_end_index_date_range.py
@@ -10,12 +10,12 @@ from .utils import assert_results_equivalent
 
 @pytest.mark.smoke
 def test_extracts_data_with_index_date_range_smoke_test(
-    load_study, setup_test_database, cohort_extractor_in_container
+    load_study, database, cohort_extractor_in_container
 ):
     study = load_study("end_to_end_index_date_range", output_file_name="cohort_*.csv")
     run_index_date_range_test(
         study,
-        setup_test_database,
+        database,
         cohort_extractor_in_container,
         expected_number_of_results=3,
     )
@@ -24,7 +24,7 @@ def test_extracts_data_with_index_date_range_smoke_test(
 @pytest.mark.integration
 def test_extracts_data_with_index_date_range_integration_test(
     load_study,
-    setup_test_database,
+    database,
     cohort_extractor_in_process,
 ):
     study = load_study(
@@ -33,7 +33,7 @@ def test_extracts_data_with_index_date_range_integration_test(
     )
     run_index_date_range_test(
         study,
-        setup_test_database,
+        database,
         cohort_extractor_in_process,
         expected_number_of_results=3,
     )
@@ -42,7 +42,7 @@ def test_extracts_data_with_index_date_range_integration_test(
 @pytest.mark.integration
 def test_cohort_function_without_index_date_range(
     load_study,
-    setup_test_database,
+    database,
     cohort_extractor_in_process,
 ):
     """A cohort function without an index date range can return a normal, single Cohort class"""
@@ -53,7 +53,7 @@ def test_cohort_function_without_index_date_range(
     )
     run_index_date_range_test(
         study,
-        setup_test_database,
+        database,
         cohort_extractor_in_process,
         expected_number_of_results=1,
         match_output_pattern=False,
@@ -103,12 +103,12 @@ def test_index_date_range_cohort_definition_errors(
 
 def run_index_date_range_test(
     study,
-    setup_test_database,
+    database,
     cohort_extractor,
     expected_number_of_results,
     match_output_pattern=True,
 ):
-    setup_test_database(
+    database.setup(
         patient(
             1,
             "F",

--- a/tests/end_to_end/test_end_to_end_tpp.py
+++ b/tests/end_to_end/test_end_to_end_tpp.py
@@ -8,25 +8,25 @@ from .utils import assert_results_equivalent
 
 @pytest.mark.smoke
 def test_extracts_data_from_sql_server_smoke_test(
-    load_study, setup_test_database, cohort_extractor_in_container
+    load_study, database, cohort_extractor_in_container
 ):
-    run_test(load_study, setup_test_database, cohort_extractor_in_container)
+    run_test(load_study, database, cohort_extractor_in_container)
 
 
 @pytest.mark.integration
 def test_extracts_data_from_sql_server_integration_test(
-    load_study, setup_test_database, cohort_extractor_in_process
+    load_study, database, cohort_extractor_in_process
 ):
-    run_test(load_study, setup_test_database, cohort_extractor_in_process)
+    run_test(load_study, database, cohort_extractor_in_process)
 
 
 @pytest.mark.integration
 def test_extracts_data_from_sql_server_integration_test_new_dsl(
-    load_study, setup_test_database, cohort_extractor_in_process
+    load_study, database, cohort_extractor_in_process
 ):
     run_test(
         load_study,
-        setup_test_database,
+        database,
         cohort_extractor_in_process,
         definition_file="tpp_cohort_new_dsl.py",
     )
@@ -34,13 +34,13 @@ def test_extracts_data_from_sql_server_integration_test_new_dsl(
 
 def run_test(
     load_study,
-    setup_test_database,
+    database,
     cohort_extractor,
     definition_file=None,
     dummy_data_file=None,
 ):
     definition_file = definition_file or "tpp_cohort.py"
-    setup_test_database(
+    database.setup(
         Patient(Patient_ID=1),
         CTV3Events(Patient_ID=1, ConsultationDate="2021-01-01", CTV3Code="xyz"),
         RegistrationHistory(Patient_ID=1),
@@ -87,13 +87,13 @@ def test_validate_cohort(load_study, cohort_extractor_in_process_no_database):
 
 @pytest.mark.integration
 def test_extracts_data_from_sql_server_ignores_dummy_data_file(
-    load_study, setup_test_database, cohort_extractor_in_process
+    load_study, database, cohort_extractor_in_process
 ):
     # A dummy data file is ignored if running in a real backend (i.e. DATABASE_URL is set)
     # This provides an invalid dummy data file, but it is ignored so no errors are raised
     run_test(
         load_study,
-        setup_test_database,
+        database,
         cohort_extractor_in_process,
         dummy_data_file="invalid_dummy_data.csv",
     )

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -22,7 +22,7 @@ def codelist_csv():
 
 
 @pytest.mark.integration
-def test_codelist_query(database, setup_test_database):
+def test_codelist_query(database):
     input_data = [
         patient(
             1,
@@ -33,7 +33,7 @@ def test_codelist_query(database, setup_test_database):
         patient(2, ctv3_event(code="bar", date="2021-01-01")),
         patient(3, ctv3_event(code="ijk", date="2021-01-01")),
     ]
-    setup_test_database(input_data)
+    database.setup(input_data)
 
     # Insert a load of extra codes as padding to force this test to exercise
     # the "insert in multiple batches" codepath
@@ -57,13 +57,13 @@ def test_codelist_query(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_codelist_equals_query(database, setup_test_database):
+def test_codelist_equals_query(database):
     input_data = [
         patient(1, ctv3_event(code="abc", date="2021-01-01")),
         patient(2, ctv3_event(code="bar", date="2021-01-01")),
         patient(3, ctv3_event(code="ijk", date="2021-01-01")),
     ]
-    setup_test_database(input_data)
+    database.setup(input_data)
 
     # A single code codelist can be expressed as an equals query
     test_codelist = codelist(["abc"], system="ctv3")
@@ -80,7 +80,7 @@ def test_codelist_equals_query(database, setup_test_database):
 
 
 @pytest.mark.integration
-def test_codelist_query_selects_correct_system(database, setup_test_database):
+def test_codelist_query_selects_correct_system(database):
     input_data = [
         patient(
             1,
@@ -90,7 +90,7 @@ def test_codelist_query_selects_correct_system(database, setup_test_database):
         patient(2, ctv3_event(code="sabc", date="2021-01-01")),
         patient(3, ctv3_event(code="ijk", date="2021-01-01", system="snomed")),
     ]
-    setup_test_database(input_data)
+    database.setup(input_data)
 
     test_codelist = codelist(["sabc", "sxyz", "ijk"], system="snomed")
 
@@ -195,15 +195,13 @@ def test_combine_codelists_different_systems():
 
 
 @pytest.mark.integration
-def test_codelist_query_with_codelist_from_csv(
-    database, setup_test_database, codelist_csv
-):
+def test_codelist_query_with_codelist_from_csv(database, codelist_csv):
     input_data = [
         patient(1, ctv3_event(code="abc", date="2021-01-01")),
         patient(2, ctv3_event(code="bar", date="2021-01-01")),
         patient(3, ctv3_event(code="ijk", date="2021-01-01")),
     ]
-    setup_test_database(input_data)
+    database.setup(input_data)
 
     codelist_csv_path = codelist_csv("long_csv")
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -7,12 +7,12 @@ from .lib.util import extract
 
 
 @pytest.mark.integration
-def test_pick_a_single_value(database, setup_test_database):
+def test_pick_a_single_value(database):
     input_data = [
         RegistrationHistory(PatientId=1),
         CTV3Events(PatientId=1, EventCode="xyz"),
     ]
-    setup_test_database(input_data)
+    database.setup(input_data)
 
     class Cohort:
         code = table("clinical_events").first_by("patient_id").get("code")


### PR DESCRIPTION
This avoids the need to have two separate fixtures which is both less typing and also (I think) conceptually correct as it makes it impossible to have mismatched database and setup fixtures.