### PR TITLE
Specify the population on a Cohort

### DIFF
--- a/cohortextractor/concepts/tables.py
+++ b/cohortextractor/concepts/tables.py
@@ -12,6 +12,15 @@ class ClinicalEvents(QueryBuilder):
         super().__init__("clinical_events")
 
 
+class PracticeRegistrations(QueryBuilder):
+    patient_id = "patient_id"
+    date_start = "date_start"
+    date_end = "date_end"
+
+    def __init__(self):
+        super().__init__("practice_registrations")
+
+
 class Patients(TableContract):
     """
     The Patients table holds personal details about the patient.
@@ -36,9 +45,9 @@ class Patients(TableContract):
 
 clinical_events = ClinicalEvents()
 patients = Patients()
+registrations = PracticeRegistrations()
 
 # Stubs
 hospitalizations = None
 patient_addresses = None
-registrations = None
 sgss_sars_cov_2 = None

--- a/cohortextractor/definition/definition.py
+++ b/cohortextractor/definition/definition.py
@@ -1,8 +1,30 @@
+from ..query_interface import Variable
 from .base import cohort_registry
 
 
 class Cohort:
-    ...
+    """Represents the cohort of patients in a study."""
+
+    population = NotImplemented
+
+    def set_population(self, population: Variable) -> None:
+        """Set the population variable for this cohort."""
+        self.add_variable("population", population)
+        if not self.population.reduce_function.__name__ == "exists":
+            raise ValueError(
+                "Population variable must return a boolean. Did you mean to use `make_one_row_per_patient(exists)`?"
+            )
+
+    def add_variable(self, name: str, variable: Variable) -> None:
+        """Add a variable to this cohort by name."""
+        if not isinstance(variable, Variable):
+            raise TypeError(
+                f"{name} must be a single value per patient (got '{variable.__class__.__name__}')"
+            )
+        self.__dict__[name] = variable
+
+    def __setattr__(self, name: str, variable: Variable) -> None:
+        return self.add_variable(name, variable)
 
 
 def register(cohort):


### PR DESCRIPTION
- Set the population variable on a Cohort
- Check that variables added to a Cohort are `Variable`s
- Check that the population variable is a boolean (the result of an `exists` query)*
- Require the population variable to be explicitly specified on a Cohort

Uses the `set_population` and `add_variable` layout from #242 

*When a table used in the DSL has knowledge of the types of its columns, I think the `make_one_row_per_patient` method (if we keep it) could record the variable type on the `Variable` (`PatientSeries`?) that it returns (which would need to be a combination of the column and the reduce function it used), and we can check that rather than the way I've done it here 

