### PR TITLE
test: Parameterise tests over all query engines

### DIFF
--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -1,0 +1,11 @@
+from ..lib.mock_backend import MockBackend
+
+
+def test_backend_tables():
+    """Test that a backend registers its table names"""
+    assert MockBackend.tables == {
+        "practice_registrations",
+        "clinical_events",
+        "patients",
+        "positive_tests",
+    }

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -1,11 +1,31 @@
-from ..lib.mock_backend import MockBackend
+from cohortextractor.backends.base import BaseBackend, Column, MappedTable
+from cohortextractor.query_engines.base_sql import BaseSQLQueryEngine
 
 
 def test_backend_tables():
     """Test that a backend registers its table names"""
-    assert MockBackend.tables == {
-        "practice_registrations",
-        "clinical_events",
+
+    class BasicBackend(BaseBackend):
+        backend_id = "basic_test_backend"
+        query_engine_class = BaseSQLQueryEngine
+        patient_join_column = "patient_id"
+
+        patients = MappedTable(
+            source="Patient",
+            columns=dict(
+                date_of_birth=Column("date", source="DateOfBirth"),
+            ),
+        )
+
+        clinical_events = MappedTable(
+            source="coded_events",
+            columns=dict(
+                code=Column("code", source="EventCode"),
+                date=Column("date", source="Date"),
+            ),
+        )
+
+    assert BasicBackend.tables == {
         "patients",
-        "positive_tests",
+        "clinical_events",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,11 @@ class QueryEngineFixture:
         return self.database.setup(*items)
 
     def extract(self, cohort, **kwargs):
-        return extract(cohort, self.backend, self.database, **kwargs)
+        results = extract(cohort, self.backend, self.database, **kwargs)
+        # We don't explicitly order the results and not all databases naturally return
+        # in the same order
+        results.sort(key=lambda i: i["patient_id"])
+        return results
 
 
 @pytest.fixture(scope="session", params=["mssql", "spark"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from cohortextractor.concepts import tables
 from cohortextractor.definition import Cohort, exists
 from cohortextractor.definition.base import cohort_registry
 from cohortextractor.query_engines.mssql import MssqlQueryEngine
+from cohortextractor.query_engines.spark import SparkQueryEngine
 
 from .lib.databases import make_database, make_spark_database, wait_for_database
 from .lib.docker import Containers
@@ -68,6 +69,12 @@ class QueryEngineFixture:
         return extract(cohort, self.backend, self.database, **kwargs)
 
 
-@pytest.fixture(scope="session")
-def engine(database):
-    return QueryEngineFixture("mssql", database, MssqlQueryEngine)
+@pytest.fixture(scope="session", params=["mssql", "spark"])
+def engine(request, database, spark_database):
+    name = request.param
+    if name == "mssql":
+        return QueryEngineFixture(name, database, MssqlQueryEngine)
+    elif name == "spark":
+        return QueryEngineFixture(name, spark_database, SparkQueryEngine)
+    else:
+        assert False

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -47,26 +47,44 @@ class MockBackend(BaseBackend):
     )
 
 
+# Generate an integer sequence to use as default IDs. Normally you'd rely on the DBMS to
+# provide these, but we need to support DBMSs like Spark which don't have this feature.
+next_id = iter(range(1, 2 ** 63)).__next__
+
+
+# We need each NULL-able column to have an explicit default of NULL. Without this,
+# SQLAlchemy will just omit empty columns from the INSERT. That's fine for most DBMSs
+# but Spark needs every column in the table to be specified, even if it just has a NULL
+# value. Note: we have to use a callable returning `None` here because if we use `None`
+# directly SQLAlchemy interprets this is "there is no default".
+def null():
+    return None
+
+
 Base = sqlalchemy.orm.declarative_base()
 
 
 class RegistrationHistory(Base):
     __tablename__ = "practice_registrations"
-    RegistrationId = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    PatientId = sqlalchemy.Column(sqlalchemy.Integer)
-    StpId = sqlalchemy.Column(sqlalchemy.String)
-    StartDate = sqlalchemy.Column(sqlalchemy.Date)
-    EndDate = sqlalchemy.Column(sqlalchemy.Date)
+    RegistrationId = sqlalchemy.Column(
+        sqlalchemy.Integer, primary_key=True, default=next_id
+    )
+    PatientId = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    StpId = sqlalchemy.Column(sqlalchemy.String, default=null)
+    StartDate = sqlalchemy.Column(sqlalchemy.Date, default=null)
+    EndDate = sqlalchemy.Column(sqlalchemy.Date, default=null)
 
 
 class CTV3Events(Base):
     __tablename__ = "events"
-    EventId = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    PatientId = sqlalchemy.Column(sqlalchemy.Integer)
-    EventCode = sqlalchemy.Column(sqlalchemy.String(collation="Latin1_General_BIN"))
-    System = sqlalchemy.Column(sqlalchemy.String)
-    Date = sqlalchemy.Column(sqlalchemy.Date)
-    ResultValue = sqlalchemy.Column(sqlalchemy.Float)
+    EventId = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
+    PatientId = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    EventCode = sqlalchemy.Column(
+        sqlalchemy.String(collation="Latin1_General_BIN"), default=null
+    )
+    System = sqlalchemy.Column(sqlalchemy.String, default=null)
+    Date = sqlalchemy.Column(sqlalchemy.Date, default=null)
+    ResultValue = sqlalchemy.Column(sqlalchemy.Float, default=null)
 
 
 def ctv3_event(code, date=None, value=None, system="ctv3"):
@@ -75,11 +93,11 @@ def ctv3_event(code, date=None, value=None, system="ctv3"):
 
 class AllTests(Base):
     __tablename__ = "all_tests"
-    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    PatientId = sqlalchemy.Column(sqlalchemy.Integer)
-    PositiveResult = sqlalchemy.Column(sqlalchemy.Boolean)
-    NegativeResult = sqlalchemy.Column(sqlalchemy.Boolean)
-    TestDate = sqlalchemy.Column(sqlalchemy.Date)
+    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
+    PatientId = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    PositiveResult = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    NegativeResult = sqlalchemy.Column(sqlalchemy.Boolean, default=null)
+    TestDate = sqlalchemy.Column(sqlalchemy.Date, default=null)
 
 
 def positive_test(result, test_date=None):
@@ -88,10 +106,10 @@ def positive_test(result, test_date=None):
 
 class Patients(Base):
     __tablename__ = "patients"
-    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    PatientId = sqlalchemy.Column(sqlalchemy.Integer)
-    Height = sqlalchemy.Column(sqlalchemy.Float)
-    DateOfBirth = sqlalchemy.Column(sqlalchemy.Date)
+    Id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True, default=next_id)
+    PatientId = sqlalchemy.Column(sqlalchemy.Integer, default=null)
+    Height = sqlalchemy.Column(sqlalchemy.Float, default=null)
+    DateOfBirth = sqlalchemy.Column(sqlalchemy.Date, default=null)
 
 
 def patient(patient_id, *entities, height=None, dob=None):

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -21,8 +21,8 @@ class MockBackend(BaseBackend):
         source="practice_registrations",
         columns=dict(
             stp=Column("varchar", source="StpId"),
-            date_start=Column("datetime", source="StartDate"),
-            date_end=Column("datetime", source="EndDate"),
+            date_start=Column("date", source="StartDate"),
+            date_end=Column("date", source="EndDate"),
         ),
     )
     clinical_events = MappedTable(
@@ -30,7 +30,7 @@ class MockBackend(BaseBackend):
         columns=dict(
             code=Column("varchar", source="EventCode"),
             system=Column("varchar", source="System"),
-            date=Column("varchar", source="Date"),
+            date=Column("date", source="Date"),
             result=Column("float", source="ResultValue"),
         ),
     )

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -58,6 +58,9 @@ def test_codelist_query(engine):
 
 @pytest.mark.integration
 def test_codelist_equals_query(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event(code="abc", date="2021-01-01")),
         patient(2, ctv3_event(code="bar", date="2021-01-01")),

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -4,8 +4,8 @@ import pytest
 
 from cohortextractor import codelist, codelist_from_csv, combine_codelists, table
 
-from .lib.mock_backend import MockBackend, ctv3_event, patient
-from .lib.util import OldCohortWithPopulation, extract
+from .lib.mock_backend import ctv3_event, patient
+from .lib.util import OldCohortWithPopulation
 
 
 @pytest.fixture

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -7,17 +7,17 @@ from .lib.util import OldCohortWithPopulation, extract
 
 
 @pytest.mark.integration
-def test_pick_a_single_value(database):
+def test_pick_a_single_value(engine):
     input_data = [
         RegistrationHistory(PatientId=1),
         CTV3Events(PatientId=1, EventCode="xyz"),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         code = table("clinical_events").first_by("patient_id").get("code")
 
     expected = [{"patient_id": 1, "code": "xyz"}]
 
-    actual = extract(Cohort, MockBackend, database)
+    actual = engine.extract(Cohort)
     assert actual == expected

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,8 +2,8 @@ import pytest
 
 from cohortextractor import table
 
-from .lib.mock_backend import CTV3Events, MockBackend, RegistrationHistory
-from .lib.util import OldCohortWithPopulation, extract
+from .lib.mock_backend import CTV3Events, RegistrationHistory
+from .lib.util import OldCohortWithPopulation
 
 
 @pytest.mark.integration

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -4,7 +4,6 @@ import pytest
 
 from cohortextractor.query_language import categorise, table
 
-from .lib.databases import null_database
 from .lib.mock_backend import (
     CTV3Events,
     MockBackend,
@@ -100,12 +99,12 @@ def test_extract_get_single_column(database):
     assert list(result) == [dict(patient_id=1, output_value="Code1")]
 
 
-def test_invalid_table():
+def test_invalid_table(database):
     class Cohort(OldCohortWithPopulation):
         output_value = table("unknown").first_by("patient_id").get("code")
 
     with pytest.raises(ValueError, match="Unknown table 'unknown'"):
-        extract(Cohort, MockBackend, null_database())
+        extract(Cohort, MockBackend, database)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -6,13 +6,12 @@ from cohortextractor.query_language import categorise, table
 
 from .lib.mock_backend import (
     CTV3Events,
-    MockBackend,
     RegistrationHistory,
     ctv3_event,
     patient,
     positive_test,
 )
-from .lib.util import OldCohortWithPopulation, extract, make_codelist
+from .lib.util import OldCohortWithPopulation, make_codelist
 
 
 # Mark the whole module as containing integration tests
@@ -37,9 +36,7 @@ def test_run_generated_sql_get_single_column_default_population(engine):
     class Cohort(OldCohortWithPopulation):
         output_value = table("clinical_events").first_by("patient_id").get("code")
 
-    assert engine.extract(Cohort) == [
-        dict(patient_id=1, output_value="Code1")
-    ]
+    assert engine.extract(Cohort) == [dict(patient_id=1, output_value="Code1")]
 
 
 def test_run_generated_sql_get_single_column_specified_population(engine):
@@ -58,9 +55,7 @@ def test_run_generated_sql_get_single_column_specified_population(engine):
         output_value = table("clinical_events").first_by("patient_id").get("code")
         population = table("practice_registrations").exists()
 
-    assert engine.extract(Cohort) == [
-        dict(patient_id=1, output_value="Code1")
-    ]
+    assert engine.extract(Cohort) == [dict(patient_id=1, output_value="Code1")]
 
 
 def test_run_generated_sql_get_multiple_columns(engine):

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -358,7 +358,15 @@ def test_run_generated_sql_get_single_row_per_patient(
         "test multiple chained filters",
     ],
 )
-def test_simple_filters(engine, data, filtered_table, expected):
+def test_simple_filters(engine, data, filtered_table, expected, request):
+    if request.node.callspec.id in [
+        "spark-test single equals filter",
+        "spark-test multiple equals filter",
+        "spark-test not equals filter",
+        "spark-test multiple chained filters",
+    ]:
+        pytest.xfail()
+
     engine.setup(data)
 
     class Cohort:
@@ -374,7 +382,10 @@ def test_simple_filters(engine, data, filtered_table, expected):
 @pytest.mark.parametrize(
     "filter_value", [[170, 180], (170, 180), {170, 180}, ("170", "180")]
 )
-def test_is_in_filter(engine, filter_value):
+def test_is_in_filter(engine, filter_value, request):
+    if request.node.callspec.id in ["spark-filter_value3"]:
+        pytest.xfail()
+
     data = [
         patient(1, ctv3_event("Code1", "2021-01-01", 10), height=180),  # in
         patient(2, ctv3_event("Code2", "2021-01-02", 20), height=170),  # not in
@@ -516,6 +527,9 @@ def test_filter_between_other_query_values(engine):
 
 
 def test_date_in_range_filter(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         # (9999-12-31 is the default TPP null value)
         # registraion start date before target date; no end date - included
@@ -558,6 +572,9 @@ def test_date_in_range_filter(engine):
 
 
 def test_in_filter_on_query_values(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     # set up input data for 2 patients, with positive test dates and clinical event results
     input_data = [
         patient(
@@ -692,6 +709,9 @@ def test_not_in_filter_on_query_values(engine):
     ids=[],
 )
 def test_aggregation(engine, aggregation, column, expected):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(
             1,
@@ -719,6 +739,9 @@ def test_aggregation(engine, aggregation, column, expected):
 
 
 def test_categorise_simple_comparisons(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [patient(1, height=180), patient(2, height=200.5), patient(3)]
     engine.setup(input_data)
 
@@ -788,6 +811,9 @@ def test_categorise_simple_comparisons(engine):
     ],
 )
 def test_categorise_single_combined_conditions(engine, categories, default, expected):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, height=180),
         patient(2, height=200.5),
@@ -807,6 +833,9 @@ def test_categorise_single_combined_conditions(engine, categories, default, expe
 
 def test_categorise_multiple_values(engine):
     """Test that categories can combine conditions that use different source values"""
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc"), height=200),
         patient(2, ctv3_event("xyz"), height=150),
@@ -832,6 +861,9 @@ def test_categorise_multiple_values(engine):
 
 
 def test_categorise_nested_comparisons(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc"), height=194),  # tall with code - matches
         patient(2, ctv3_event("xyz"), height=200.5),  # tall no code  - matches
@@ -868,6 +900,9 @@ def test_categorise_nested_comparisons(engine):
 
 def test_categorise_on_truthiness(engine):
     """Test truthiness of a Value from an exists aggregation"""
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz")),
@@ -892,6 +927,9 @@ def test_categorise_on_truthiness(engine):
 
 def test_categorise_on_truthiness_from_filter(engine):
     """Test truthiness of a Value from a filtered value"""
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz")),
@@ -921,6 +959,9 @@ def test_categorise_on_truthiness_from_filter(engine):
 
 def test_categorise_multiple_truthiness_values(engine):
     """Test truthiness of a Value from a filtered value"""
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc"), positive_test(True)),
         patient(2, ctv3_event("xyz"), positive_test(False)),
@@ -950,6 +991,9 @@ def test_categorise_multiple_truthiness_values(engine):
 
 
 def test_categorise_invert(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, height=194),
         patient(2, height=160.5),
@@ -982,6 +1026,9 @@ def test_categorise_invert(engine):
 
 
 def test_categorise_invert_truthiness_values(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz")),
@@ -1010,6 +1057,9 @@ def test_categorise_invert_truthiness_values(engine):
 
 
 def test_categorise_invert_combined_values(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc"), positive_test(True)),
         patient(2, ctv3_event("xyz"), positive_test(False)),
@@ -1039,6 +1089,9 @@ def test_categorise_invert_combined_values(engine):
 
 
 def test_categorise_double_invert(engine):
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz")),
@@ -1077,6 +1130,9 @@ def test_categorise_multiple_truthiness_categories(engine):
     ValueFromRow is a Row, which can't be sorted.  THis test checks the workaround for
     this scenario.
     """
+    if engine.name == "spark":
+        pytest.xfail()
+
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz"), ctv3_event("lmn")),

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -1189,6 +1189,9 @@ def test_age_as_of(engine):
 
 
 def test_fetching_results_using_temporary_database(engine):
+    if engine.name == "spark":
+        pytest.skip("Spark does not support 'fetch using temporary database'")
+
     engine.setup(
         [
             patient(1, ctv3_event("abc", "2020-01-01")),

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -20,16 +20,6 @@ from .lib.util import OldCohortWithPopulation, extract, make_codelist
 pytestmark = pytest.mark.integration
 
 
-def test_backend_tables():
-    """Test that a backend registers its table names"""
-    assert MockBackend.tables == {
-        "practice_registrations",
-        "clinical_events",
-        "patients",
-        "positive_tests",
-    }
-
-
 def test_run_generated_sql_get_single_column_default_population(database):
     input_data = [
         patient(

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -19,7 +19,7 @@ from .lib.util import OldCohortWithPopulation, extract, make_codelist
 pytestmark = pytest.mark.integration
 
 
-def test_run_generated_sql_get_single_column_default_population(database):
+def test_run_generated_sql_get_single_column_default_population(engine):
     input_data = [
         patient(
             1,
@@ -28,7 +28,7 @@ def test_run_generated_sql_get_single_column_default_population(database):
         # patient 2 has an event, but no RegistrationHistory entry
         CTV3Events(PatientId=2, EventCode="Code2", System="ctv3"),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract all clinical events and return just the code column
     # Note that the RegistrationHistory table is used for the default population query
@@ -37,18 +37,18 @@ def test_run_generated_sql_get_single_column_default_population(database):
     class Cohort(OldCohortWithPopulation):
         output_value = table("clinical_events").first_by("patient_id").get("code")
 
-    assert extract(Cohort, MockBackend, database) == [
+    assert engine.extract(Cohort) == [
         dict(patient_id=1, output_value="Code1")
     ]
 
 
-def test_run_generated_sql_get_single_column_specified_population(database):
+def test_run_generated_sql_get_single_column_specified_population(engine):
     input_data = [
         patient(1, ctv3_event("Code1")),
         # patient 2 has an event, but no RegistrationHistory entry
         CTV3Events(PatientId=2, EventCode="Code2", System="ctv3"),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract all clinical events and return just the code column
     # Note that the RegistrationHistory table is used for the default population query
@@ -58,35 +58,35 @@ def test_run_generated_sql_get_single_column_specified_population(database):
         output_value = table("clinical_events").first_by("patient_id").get("code")
         population = table("practice_registrations").exists()
 
-    assert extract(Cohort, MockBackend, database) == [
+    assert engine.extract(Cohort) == [
         dict(patient_id=1, output_value="Code1")
     ]
 
 
-def test_run_generated_sql_get_multiple_columns(database):
+def test_run_generated_sql_get_multiple_columns(engine):
     input_data = [
         patient(1, ctv3_event("Code1"), positive_test(True)),
         patient(2, ctv3_event("Code2"), positive_test(False)),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract all clinical events and positive tests
     class Cohort(OldCohortWithPopulation):
         output_value = table("clinical_events").first_by("patient_id").get("code")
         positive = table("positive_tests").first_by("patient_id").get("result")
 
-    assert extract(Cohort, MockBackend, database) == [
+    assert engine.extract(Cohort) == [
         dict(patient_id=1, output_value="Code1", positive=True),
         dict(patient_id=2, output_value="Code2", positive=False),
     ]
 
 
-def test_extract_get_single_column(database):
+def test_extract_get_single_column(engine):
     input_data = [
         patient(1, ctv3_event("Code1")),
         CTV3Events(PatientId=2, EventCode="Code2", System="ctv3"),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract all clinical events and return just the code column
     # Note that the RegistrationHistory table is used for the default population query
@@ -95,16 +95,16 @@ def test_extract_get_single_column(database):
     class Cohort(OldCohortWithPopulation):
         output_value = table("clinical_events").first_by("patient_id").get("code")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert list(result) == [dict(patient_id=1, output_value="Code1")]
 
 
-def test_invalid_table(database):
+def test_invalid_table(engine):
     class Cohort(OldCohortWithPopulation):
         output_value = table("unknown").first_by("patient_id").get("code")
 
     with pytest.raises(ValueError, match="Unknown table 'unknown'"):
-        extract(Cohort, MockBackend, database)
+        engine.extract(Cohort)
 
 
 @pytest.mark.parametrize(
@@ -129,7 +129,7 @@ def test_invalid_table(database):
     ],
 )
 def test_run_generated_sql_get_single_row_per_patient(
-    database, code_output, date_output, expected
+    engine, code_output, date_output, expected
 ):
     input_data = [
         patient(
@@ -142,14 +142,14 @@ def test_run_generated_sql_get_single_row_per_patient(
             2, ctv3_event("Code1", "2021-06-05"), ctv3_event("Code1", "2021-02-04")
         ),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract the earliest/latest event for each patient, and return code and date
     class Cohort(OldCohortWithPopulation):
         code = code_output
         date = date_output
 
-    assert extract(Cohort, MockBackend, database) == expected
+    assert engine.extract(Cohort) == expected
 
 
 @pytest.mark.parametrize(
@@ -363,8 +363,8 @@ def test_run_generated_sql_get_single_row_per_patient(
         "test multiple chained filters",
     ],
 )
-def test_simple_filters(database, data, filtered_table, expected):
-    database.setup(data)
+def test_simple_filters(engine, data, filtered_table, expected):
+    engine.setup(data)
 
     class Cohort:
         population = filtered_table.exists()
@@ -373,19 +373,19 @@ def test_simple_filters(database, data, filtered_table, expected):
         date = _filtered.get("date")
         value = _filtered.get("result")
 
-    assert extract(Cohort, MockBackend, database) == expected
+    assert engine.extract(Cohort) == expected
 
 
 @pytest.mark.parametrize(
     "filter_value", [[170, 180], (170, 180), {170, 180}, ("170", "180")]
 )
-def test_is_in_filter(database, filter_value):
+def test_is_in_filter(engine, filter_value):
     data = [
         patient(1, ctv3_event("Code1", "2021-01-01", 10), height=180),  # in
         patient(2, ctv3_event("Code2", "2021-01-02", 20), height=170),  # not in
     ]
 
-    database.setup(data)
+    engine.setup(data)
 
     class Cohort:
         _filtered_table = table("patients").filter("height", is_in=filter_value)
@@ -397,7 +397,7 @@ def test_is_in_filter(database, filter_value):
         dict(patient_id=1, height=180),
         dict(patient_id=2, height=170),
     ]
-    assert extract(Cohort, MockBackend, database) == expected
+    assert engine.extract(Cohort) == expected
 
 
 @pytest.mark.parametrize(
@@ -418,8 +418,8 @@ def test_is_in_filter(database, filter_value):
         ),
     ],
 )
-def test_filter_with_nulls(database, filtered_table, expected):
-    database.setup(
+def test_filter_with_nulls(engine, filtered_table, expected):
+    engine.setup(
         [
             patient(
                 1, ctv3_event("Code1", "2021-01-01", 10)
@@ -438,10 +438,10 @@ def test_filter_with_nulls(database, filtered_table, expected):
         date = _filtered_per_patient.get("date")
         value = _filtered_per_patient.get("result")
 
-    assert extract(Cohort, MockBackend, database) == expected
+    assert engine.extract(Cohort) == expected
 
 
-def test_filter_between_other_query_values(database):
+def test_filter_between_other_query_values(engine):
     # set up input data for 3 patients, with positive test dates and clinical event results
     input_data = [
         patient(
@@ -478,7 +478,7 @@ def test_filter_between_other_query_values(database):
             ctv3_event("Code2", "2021-02-01", system="snomed", value=60.3),
         ),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract the last Code1 result between a patient's first and last positive test dates
     class Cohort(OldCohortWithPopulation):
@@ -494,7 +494,7 @@ def test_filter_between_other_query_values(database):
         date = _events.get("date")
         value = _events.get("result")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(
             patient_id=1,
@@ -520,7 +520,7 @@ def test_filter_between_other_query_values(database):
     ]
 
 
-def test_date_in_range_filter(database):
+def test_date_in_range_filter(engine):
     input_data = [
         # (9999-12-31 is the default TPP null value)
         # registraion start date before target date; no end date - included
@@ -546,14 +546,14 @@ def test_date_in_range_filter(database):
             PatientId=4, StpId="STP3", StartDate="2021-01-01", EndDate="2021-03-03"
         ),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _registrations = table("practice_registrations").date_in_range("2021-03-02")
         stp = _registrations.first_by("patient_id").get("stp")
         count = _registrations.count("patient_id")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, stp="STP1", count=1),
         dict(patient_id=2, stp=None, count=None),
@@ -562,7 +562,7 @@ def test_date_in_range_filter(database):
     ]
 
 
-def test_in_filter_on_query_values(database):
+def test_in_filter_on_query_values(engine):
     # set up input data for 2 patients, with positive test dates and clinical event results
     input_data = [
         patient(
@@ -592,7 +592,7 @@ def test_in_filter_on_query_values(database):
         ),
     ]
 
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract the Code1 results that were on a positive test date
     class Cohort(OldCohortWithPopulation):
@@ -608,14 +608,14 @@ def test_in_filter_on_query_values(database):
         date = _last_code1_events_on_positive_test_dates.get("date")
         value = _last_code1_events_on_positive_test_dates.get("result")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, date=date(2021, 2, 15), value=10.2),
         dict(patient_id=2, date=date(2021, 1, 10), value=50.1),
     ]
 
 
-def test_not_in_filter_on_query_values(database):
+def test_not_in_filter_on_query_values(engine):
     # set up input data for 2 patients, with positive test dates and clinical event results
 
     input_data = [
@@ -645,7 +645,7 @@ def test_not_in_filter_on_query_values(database):
         ),
     ]
 
-    database.setup(input_data)
+    engine.setup(input_data)
 
     # Cohort to extract the results that were NOT on a test date (positive or negative)
     class Cohort(OldCohortWithPopulation):
@@ -656,7 +656,7 @@ def test_not_in_filter_on_query_values(database):
         date = _last_event_not_on_test_date.get("date")
         value = _last_event_not_on_test_date.get("result")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, date=date(2021, 4, 1), value=10.3),
         dict(patient_id=2, date=date(2021, 5, 2), value=50.3),
@@ -696,7 +696,7 @@ def test_not_in_filter_on_query_values(database):
     ],
     ids=[],
 )
-def test_aggregation(database, aggregation, column, expected):
+def test_aggregation(engine, aggregation, column, expected):
     input_data = [
         patient(
             1,
@@ -714,18 +714,18 @@ def test_aggregation(database, aggregation, column, expected):
             ctv3_event("Code2", value=70.1),
         ),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _filtered_table = table("clinical_events").filter(code=make_codelist("Code1"))
         value = getattr(_filtered_table, aggregation)(column)
 
-    assert extract(Cohort, MockBackend, database) == expected
+    assert engine.extract(Cohort) == expected
 
 
-def test_categorise_simple_comparisons(database):
+def test_categorise_simple_comparisons(engine):
     input_data = [patient(1, height=180), patient(2, height=200.5), patient(3)]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _height = table("patients").first_by("patient_id").get("height")
@@ -735,7 +735,7 @@ def test_categorise_simple_comparisons(database):
         }
         height_group = categorise(_height_categories, default="missing")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, height_group="short"),
         dict(patient_id=2, height_group="tall"),
@@ -792,32 +792,32 @@ def test_categorise_simple_comparisons(database):
         "test a not-equals condition",
     ],
 )
-def test_categorise_single_combined_conditions(database, categories, default, expected):
+def test_categorise_single_combined_conditions(engine, categories, default, expected):
     input_data = [
         patient(1, height=180),
         patient(2, height=200.5),
         patient(3),
         patient(4, height=145),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _height = table("patients").first_by("patient_id").get("height")
         _height_categories = categories(_height)
         height_group = categorise(_height_categories, default=default)
 
-    result = list(extract(Cohort, MockBackend, database))
+    result = list(engine.extract(Cohort))
     assert result == expected
 
 
-def test_categorise_multiple_values(database):
+def test_categorise_multiple_values(engine):
     """Test that categories can combine conditions that use different source values"""
     input_data = [
         patient(1, ctv3_event("abc"), height=200),
         patient(2, ctv3_event("xyz"), height=150),
         patient(3, ctv3_event("abc"), height=160),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _height = table("patients").first_by("patient_id").get("height")
@@ -828,7 +828,7 @@ def test_categorise_multiple_values(database):
         }
         height_group = categorise(_height_with_codes_categories, default="missing")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, height_group="tall"),
         dict(patient_id=2, height_group="missing"),
@@ -836,7 +836,7 @@ def test_categorise_multiple_values(database):
     ]
 
 
-def test_categorise_nested_comparisons(database):
+def test_categorise_nested_comparisons(engine):
     input_data = [
         patient(1, ctv3_event("abc"), height=194),  # tall with code - matches
         patient(2, ctv3_event("xyz"), height=200.5),  # tall no code  - matches
@@ -844,7 +844,7 @@ def test_categorise_nested_comparisons(database):
         patient(4, height=140.5),  # short no code
         patient(5),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _height = table("patients").first_by("patient_id").get("height")
@@ -860,7 +860,7 @@ def test_categorise_nested_comparisons(database):
         height_group = categorise(_height_with_codes_categories, default="na")
         height_group1 = categorise(_codes_with_height_categories, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
 
     assert result == [
         dict(patient_id=1, height_group="tall_or_code", height_group1="code_or_tall"),
@@ -871,7 +871,7 @@ def test_categorise_nested_comparisons(database):
     ]
 
 
-def test_categorise_on_truthiness(database):
+def test_categorise_on_truthiness(engine):
     """Test truthiness of a Value from an exists aggregation"""
     input_data = [
         patient(1, ctv3_event("abc")),
@@ -879,14 +879,14 @@ def test_categorise_on_truthiness(database):
         patient(3, ctv3_event("abc")),
         patient(4),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _code = table("clinical_events").filter(code=make_codelist("abc")).exists()
         _codes_categories = {"yes": _code}
         abc = categorise(_codes_categories, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, abc="yes"),
         dict(patient_id=2, abc="na"),
@@ -895,7 +895,7 @@ def test_categorise_on_truthiness(database):
     ]
 
 
-def test_categorise_on_truthiness_from_filter(database):
+def test_categorise_on_truthiness_from_filter(engine):
     """Test truthiness of a Value from a filtered value"""
     input_data = [
         patient(1, ctv3_event("abc")),
@@ -903,7 +903,7 @@ def test_categorise_on_truthiness_from_filter(database):
         patient(3, ctv3_event("abc")),
         patient(4, ctv3_event("def")),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _code = (
@@ -915,7 +915,7 @@ def test_categorise_on_truthiness_from_filter(database):
         _codes_categories = {"yes": _code}
         has_code = categorise(_codes_categories, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, has_code="yes"),
         dict(patient_id=2, has_code="na"),
@@ -924,7 +924,7 @@ def test_categorise_on_truthiness_from_filter(database):
     ]
 
 
-def test_categorise_multiple_truthiness_values(database):
+def test_categorise_multiple_truthiness_values(engine):
     """Test truthiness of a Value from a filtered value"""
     input_data = [
         patient(1, ctv3_event("abc"), positive_test(True)),
@@ -932,7 +932,7 @@ def test_categorise_multiple_truthiness_values(database):
         patient(3, ctv3_event("abc"), positive_test(False)),
         patient(4, ctv3_event("def"), positive_test(True)),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _code = (
@@ -945,7 +945,7 @@ def test_categorise_multiple_truthiness_values(database):
         _codes_categories = {"yes": _code & _has_positive_test}
         has_positive_code = categorise(_codes_categories, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, has_positive_code="yes"),
         dict(patient_id=2, has_positive_code="na"),
@@ -954,7 +954,7 @@ def test_categorise_multiple_truthiness_values(database):
     ]
 
 
-def test_categorise_invert(database):
+def test_categorise_invert(engine):
     input_data = [
         patient(1, height=194),
         patient(2, height=160.5),
@@ -962,7 +962,7 @@ def test_categorise_invert(database):
         patient(4, height=140.5),
         RegistrationHistory(PatientId=5),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _height = table("patients").first_by("patient_id").get("height")
@@ -975,7 +975,7 @@ def test_categorise_invert(database):
         }
         height_group = categorise(_height_inverted, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
 
     assert result == [
         dict(patient_id=1, height_group="tall"),
@@ -986,14 +986,14 @@ def test_categorise_invert(database):
     ]
 
 
-def test_categorise_invert_truthiness_values(database):
+def test_categorise_invert_truthiness_values(engine):
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz")),
         patient(3, ctv3_event("abc")),
         patient(4, ctv3_event("def")),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _code = (
@@ -1005,7 +1005,7 @@ def test_categorise_invert_truthiness_values(database):
         _codes_categories = {"yes": _code, "no": ~_code}
         has_code = categorise(_codes_categories, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, has_code="yes"),
         dict(patient_id=2, has_code="no"),
@@ -1014,14 +1014,14 @@ def test_categorise_invert_truthiness_values(database):
     ]
 
 
-def test_categorise_invert_combined_values(database):
+def test_categorise_invert_combined_values(engine):
     input_data = [
         patient(1, ctv3_event("abc"), positive_test(True)),
         patient(2, ctv3_event("xyz"), positive_test(False)),
         patient(3, ctv3_event("abc"), positive_test(False)),
         patient(4, ctv3_event("def"), positive_test(True)),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _code = (
@@ -1034,7 +1034,7 @@ def test_categorise_invert_combined_values(database):
         _codes_categories = {"neg_or_no_code": ~(_code & _has_positive_test)}
         result_group = categorise(_codes_categories, default="pos")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, result_group="pos"),
         dict(patient_id=2, result_group="neg_or_no_code"),
@@ -1043,14 +1043,14 @@ def test_categorise_invert_combined_values(database):
     ]
 
 
-def test_categorise_double_invert(database):
+def test_categorise_double_invert(engine):
     input_data = [
         patient(1, ctv3_event("abc")),
         patient(2, ctv3_event("xyz")),
         patient(3, ctv3_event("abc")),
         patient(4, ctv3_event("def")),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _code = (
@@ -1062,7 +1062,7 @@ def test_categorise_double_invert(database):
         _codes_categories = {"yes": ~~_code}
         has_code = categorise(_codes_categories, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, has_code="yes"),
         dict(patient_id=2, has_code="na"),
@@ -1071,7 +1071,7 @@ def test_categorise_double_invert(database):
     ]
 
 
-def test_categorise_multiple_truthiness_categories(database):
+def test_categorise_multiple_truthiness_categories(engine):
     """
     Test categorisation on multiple truthy values
     This tests for a previous bug in sorting the reference nodes in category definitions.
@@ -1089,7 +1089,7 @@ def test_categorise_multiple_truthiness_categories(database):
         patient(4, ctv3_event("def")),
         patient(5),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         _codes_1 = (
@@ -1107,7 +1107,7 @@ def test_categorise_multiple_truthiness_categories(database):
         _codes_categories = {"1": _codes_1, "2": _codes_2}
         has_positive_code = categorise(_codes_categories, default="na")
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         dict(patient_id=1, has_positive_code="1"),
         dict(patient_id=2, has_positive_code="2"),
@@ -1117,12 +1117,12 @@ def test_categorise_multiple_truthiness_categories(database):
     ]
 
 
-def test_age_as_of(database):
+def test_age_as_of(engine):
     input_data = [
         patient(1, ctv3_event("abc", "2020-10-01"), dob="1990-8-10"),
         patient(2, ctv3_event("abc", "2018-02-01"), dob="2000-03-20"),
     ]
-    database.setup(input_data)
+    engine.setup(input_data)
 
     class Cohort(OldCohortWithPopulation):
         age_in_2010 = table("patients").age_as_of("2010-06-01")
@@ -1130,15 +1130,15 @@ def test_age_as_of(database):
             table("clinical_events").latest().get("date")
         )
 
-    result = extract(Cohort, MockBackend, database)
+    result = engine.extract(Cohort)
     assert result == [
         {"patient_id": 1, "age_in_2010": 19, "age_at_last_event": 30},
         {"patient_id": 2, "age_in_2010": 10, "age_at_last_event": 17},
     ]
 
 
-def test_fetching_results_using_temporary_database(database):
-    database.setup(
+def test_fetching_results_using_temporary_database(engine):
+    engine.setup(
         [
             patient(1, ctv3_event("abc", "2020-01-01")),
             patient(2, ctv3_event("xyz", "2020-01-01")),
@@ -1148,7 +1148,7 @@ def test_fetching_results_using_temporary_database(database):
     class Cohort(OldCohortWithPopulation):
         code = table("clinical_events").latest().get("code")
 
-    assert extract(Cohort, MockBackend, database, temporary_database="temp_tables") == [
+    assert engine.extract(Cohort, temporary_database="temp_tables") == [
         dict(patient_id=1, code="abc"),
         dict(patient_id=2, code="xyz"),
     ]

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -16,6 +16,10 @@ from .lib.mock_backend import (
 from .lib.util import OldCohortWithPopulation, extract, make_codelist
 
 
+# Mark the whole module as containing integration tests
+pytestmark = pytest.mark.integration
+
+
 def test_backend_tables():
     """Test that a backend registers its table names"""
     assert MockBackend.tables == {
@@ -26,7 +30,6 @@ def test_backend_tables():
     }
 
 
-@pytest.mark.integration
 def test_run_generated_sql_get_single_column_default_population(database):
     input_data = [
         patient(
@@ -50,7 +53,6 @@ def test_run_generated_sql_get_single_column_default_population(database):
     ]
 
 
-@pytest.mark.integration
 def test_run_generated_sql_get_single_column_specified_population(database):
     input_data = [
         patient(1, ctv3_event("Code1")),
@@ -72,7 +74,6 @@ def test_run_generated_sql_get_single_column_specified_population(database):
     ]
 
 
-@pytest.mark.integration
 def test_run_generated_sql_get_multiple_columns(database):
     input_data = [
         patient(1, ctv3_event("Code1"), positive_test(True)),
@@ -91,7 +92,6 @@ def test_run_generated_sql_get_multiple_columns(database):
     ]
 
 
-@pytest.mark.integration
 def test_extract_get_single_column(database):
     input_data = [
         patient(1, ctv3_event("Code1")),
@@ -118,7 +118,6 @@ def test_invalid_table():
         extract(Cohort, MockBackend, null_database())
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "code_output,date_output,expected",
     [
@@ -164,7 +163,6 @@ def test_run_generated_sql_get_single_row_per_patient(
     assert extract(Cohort, MockBackend, database) == expected
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "data,filtered_table,expected",
     [
@@ -413,7 +411,6 @@ def test_is_in_filter(database, filter_value):
     assert extract(Cohort, MockBackend, database) == expected
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "filtered_table,expected",
     [
@@ -455,7 +452,6 @@ def test_filter_with_nulls(database, filtered_table, expected):
     assert extract(Cohort, MockBackend, database) == expected
 
 
-@pytest.mark.integration
 def test_filter_between_other_query_values(database):
     # set up input data for 3 patients, with positive test dates and clinical event results
     input_data = [
@@ -535,7 +531,6 @@ def test_filter_between_other_query_values(database):
     ]
 
 
-@pytest.mark.integration
 def test_date_in_range_filter(database):
     input_data = [
         # (9999-12-31 is the default TPP null value)
@@ -578,7 +573,6 @@ def test_date_in_range_filter(database):
     ]
 
 
-@pytest.mark.integration
 def test_in_filter_on_query_values(database):
     # set up input data for 2 patients, with positive test dates and clinical event results
     input_data = [
@@ -632,7 +626,6 @@ def test_in_filter_on_query_values(database):
     ]
 
 
-@pytest.mark.integration
 def test_not_in_filter_on_query_values(database):
     # set up input data for 2 patients, with positive test dates and clinical event results
 
@@ -681,7 +674,6 @@ def test_not_in_filter_on_query_values(database):
     ]
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "aggregation,column,expected",
     [
@@ -742,7 +734,6 @@ def test_aggregation(database, aggregation, column, expected):
     assert extract(Cohort, MockBackend, database) == expected
 
 
-@pytest.mark.integration
 def test_categorise_simple_comparisons(database):
     input_data = [patient(1, height=180), patient(2, height=200.5), patient(3)]
     database.setup(input_data)
@@ -763,7 +754,6 @@ def test_categorise_simple_comparisons(database):
     ]
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "categories,default,expected",
     [
@@ -831,7 +821,6 @@ def test_categorise_single_combined_conditions(database, categories, default, ex
     assert result == expected
 
 
-@pytest.mark.integration
 def test_categorise_multiple_values(database):
     """Test that categories can combine conditions that use different source values"""
     input_data = [
@@ -858,7 +847,6 @@ def test_categorise_multiple_values(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_nested_comparisons(database):
     input_data = [
         patient(1, ctv3_event("abc"), height=194),  # tall with code - matches
@@ -894,7 +882,6 @@ def test_categorise_nested_comparisons(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_on_truthiness(database):
     """Test truthiness of a Value from an exists aggregation"""
     input_data = [
@@ -919,7 +906,6 @@ def test_categorise_on_truthiness(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_on_truthiness_from_filter(database):
     """Test truthiness of a Value from a filtered value"""
     input_data = [
@@ -949,7 +935,6 @@ def test_categorise_on_truthiness_from_filter(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_multiple_truthiness_values(database):
     """Test truthiness of a Value from a filtered value"""
     input_data = [
@@ -980,7 +965,6 @@ def test_categorise_multiple_truthiness_values(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_invert(database):
     input_data = [
         patient(1, height=194),
@@ -1013,7 +997,6 @@ def test_categorise_invert(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_invert_truthiness_values(database):
     input_data = [
         patient(1, ctv3_event("abc")),
@@ -1042,7 +1025,6 @@ def test_categorise_invert_truthiness_values(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_invert_combined_values(database):
     input_data = [
         patient(1, ctv3_event("abc"), positive_test(True)),
@@ -1072,7 +1054,6 @@ def test_categorise_invert_combined_values(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_double_invert(database):
     input_data = [
         patient(1, ctv3_event("abc")),
@@ -1101,7 +1082,6 @@ def test_categorise_double_invert(database):
     ]
 
 
-@pytest.mark.integration
 def test_categorise_multiple_truthiness_categories(database):
     """
     Test categorisation on multiple truthy values
@@ -1148,7 +1128,6 @@ def test_categorise_multiple_truthiness_categories(database):
     ]
 
 
-@pytest.mark.integration
 def test_age_as_of(database):
     input_data = [
         patient(1, ctv3_event("abc", "2020-10-01"), dob="1990-8-10"),
@@ -1169,7 +1148,6 @@ def test_age_as_of(database):
     ]
 
 
-@pytest.mark.integration
 def test_fetching_results_using_temporary_database(database):
     database.setup(
         [


### PR DESCRIPTION
This PR creates an `engine()` pytest fixture which returns a `QueryEngineFixture()` object. This object provides the machinery required to write a test against a QueryEngine which is agnostic as to which particular query engine it runs against. We then update all the existing tests for which it makes sense to do so to use this new fixture. And finally we parameterise the fixture so the tests end up running over all our query engines.

There are a few caveats to this glorious conclusion:

1. Not all the tests against Spark actually pass. I have marked all the failing ones as xfail because I don't think fixing all the Spark issues belongs in this PR and have created separate tickets to track the three classes of failure that we're seeing:
    - #249
    - #250
    - #251

2. The Spark tests are annoyingly slow. Previously the entire test suite took 40s to run 236 tests. Now it takes 2m 54s to run 292 tests. It's easy enough to skip them locally using `-k 'not spark'` but that's obviously not ideal. I've created a separate ticket to track this and record the things I've tried already:
    - #248

3. I haven't done anything in the way of adding types to this yet, though it does pass the `mypy` check.