### PR TITLE
feat: add `test_connection` command

### DIFF
--- a/cohortextractor/__main__.py
+++ b/cohortextractor/__main__.py
@@ -4,7 +4,13 @@ from argparse import ArgumentParser, ArgumentTypeError
 from pathlib import Path
 
 from .backends import BACKENDS
-from .main import generate_cohort, generate_measures, run_cohort_action, validate_cohort
+from .main import (
+    generate_cohort,
+    generate_measures,
+    run_cohort_action,
+    test_connection,
+    validate_cohort,
+)
 
 
 def main(argv):
@@ -38,6 +44,11 @@ def main(argv):
             definition_path=options.cohort_definition,
             input_file=options.input,
             output_file=options.output,
+        )
+    elif options.which == "test_connection":
+        test_connection(
+            backend=options.backend,
+            url=options.url,
         )
     elif options.which == "print_help":
         parser.print_help()
@@ -114,6 +125,25 @@ def build_parser():
         "--cohort-definition",
         help="The path of the file where the cohort is defined",
         type=existing_python_file,
+    )
+
+    test_connection_parser = subparsers.add_parser(
+        "test_connection", help="test the database connection configuration"
+    )
+    test_connection_parser.set_defaults(which="test_connection")
+
+    test_connection_parser.add_argument(
+        "--backend",
+        "-b",
+        help="backend type to test",
+        default=os.environ.get("BACKEND", os.environ.get("OPENSAFELY_BACKEND")),
+    )
+
+    test_connection_parser.add_argument(
+        "--url",
+        "-u",
+        help="db url",
+        default=os.environ.get("DATABASE_URL"),
     )
 
     return parser

--- a/cohortextractor/main.py
+++ b/cohortextractor/main.py
@@ -130,6 +130,16 @@ def generate_measures(definition_path, input_file, output_file):
         log.info(f"Combined measure output for all dates in {output_file}")
 
 
+def test_connection(backend, url):
+    from sqlalchemy import select
+
+    backend = BACKENDS[backend](url, temporary_database=None)
+    query_engine = backend.query_engine_class({}, backend)
+    with query_engine.engine.connect() as connection:
+        connection.execute(select(1))
+    print("SUCCESS")
+
+
 def _replace_filepath_pattern(filepath, filename_part):
     """
     Take a filepath and replace a '*' with the specified filename part

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -122,3 +122,12 @@ def test_existing_python_file_unpythonic_file(capsys, tmp_path):
         main(argv)
     captured = capsys.readouterr()
     assert "cohort.cpp is not a Python file" in captured.err
+
+
+def test_test_connection(monkeypatch, database, capsys):
+    monkeypatch.setenv("BACKEND", "tpp")
+    monkeypatch.setenv("DATABASE_URL", database.host_url())
+    argv = ["test_connection"]
+    main(argv)
+    out, _ = capsys.readouterr()
+    assert "SUCCESS" in out


### PR DESCRIPTION
This command issues a simpler `SELECT 1` query to make sure our code can
connect with the given connection string.

This is designed to help folks running job-runner to be able to diagnose
configuration issues.
