### PR TITLE
Automate versioning

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,32 @@
+name: Tag repo; build and publish assets
+on:
+  create:
+    tags: ['v*']
+  workspace_dispatch:
+
+jobs:
+  build-and-publish-docker-image:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      image: ghcr.io/opensafely-core/cohortextractor-v2:latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get current git tag
+        id: tags
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag ${{ env.image }}
+
+      - name: Log into GitHub Container Registry
+        run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
+
+      - name: Push image to GitHub Container Registry
+        env:
+          VERSION: ${{ steps.tags.outputs.tag }}
+        run: |
+          docker tag ${{ env.image }} ${{ env.image }}:latest
+          docker tag ${{ env.image }} ${{ env.image }}:$VERSION
+          docker push ${{ env.image }}:$VERSION

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,17 +43,27 @@ jobs:
         with:
           failure-threshold: error
 
-  docker-publish:
-    if: github.ref == 'refs/heads/main'
+  tag-new-version:
+    # This uses `conventional commits` to generate tags.  A full list
+    # of valid prefixes is here:
+    # https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+    #
+    # fix, perf -> patch release
+    # feat -> minor release
+    # BREAKING CHANGE in footer -> major release
+    #
+    # anything else (docs, refactor, etc) does not create a release
     runs-on: ubuntu-latest
-    needs: [test, lint-dockerfile]
-    env:
-      image: ghcr.io/opensafely-core/cohortextractor-v2:latest
+    outputs:
+      tag: ${{ steps.tag.outputs.new_version }}
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: docker build . --file Dockerfile --tag ${{ env.image }}
-      - name: Log into GitHub Container Registry
-        run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
-      - name: Push image to GitHub Container Registry
-        run: docker push ${{ env.image }}
+        with:
+          fetch-depth: 0
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@981ffb2cc3f2b684b2bfd8ee17bc8d781368ba60
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          release_branches: main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "cohortextractor"
 description = ""
-version = "2.0.0"
+version = "not-a-package"
 readme = "README.md"
 authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
 license = {file = "LICENSE"}


### PR DESCRIPTION
This sets up automated versioning for the project.  There are a few pieces to the puzzle:

* remove the version from pyproject.toml since we're not publishing as a package to any indexes
* configure automated tagging with an action for commits to main
* a new workflow to detect new tags to main and build the docker image with that [git] tag

This means we can pip install from the git tag to get the desired version.