### PR TITLE
fix: Only tag working builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,12 +1,11 @@
 name: Tag repo; build and publish assets
 on:
   create:
-    tags: ['v*']
   workflow_dispatch:
 
 jobs:
   build-and-publish-docker-image:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     env:
       image: ghcr.io/opensafely-core/cohortextractor-v2:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
     # BREAKING CHANGE in footer -> major release
     #
     # anything else (docs, refactor, etc) does not create a release
+    needs: [test]
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.new_version }}


### PR DESCRIPTION
While the tagging job only runs on the main branch, this also makes sure the tests pass too.