### PR TITLE
fix: only tag with `latest` at docker build time

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     env:
-      image: ghcr.io/opensafely-core/cohortextractor-v2:latest
+      image: ghcr.io/opensafely-core/cohortextractor-v2
     steps:
       - uses: actions/checkout@v2
 
@@ -17,7 +17,7 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag ${{ env.image }}
+        run: docker build . --file Dockerfile --tag ${{ env.image }}:latest
 
       - name: Log into GitHub Container Registry
         run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}


### PR DESCRIPTION
Otherwise we end up trying to tag it with `ghcr.io/opensafely-core/cohortextractor-v2:latest:$VERSION` further down.