### PR TITLE
Simple column type-checking for backend contracts

### DIFF
--- a/cohortextractor/backends/base.py
+++ b/cohortextractor/backends/base.py
@@ -64,7 +64,7 @@ class SQLTable:
 
     def _make_column(self, name, column):
         source = column.source or name
-        type_ = TYPES_BY_NAME[column.type]
+        type_ = TYPES_BY_NAME[column.type].value
         sql_column = sqlalchemy.Column(source, type_)
         if source != name:
             sql_column = sql_column.label(name)

--- a/cohortextractor/concepts/table_contract.py
+++ b/cohortextractor/concepts/table_contract.py
@@ -46,6 +46,6 @@ class TableContract:
                 raise BackendContractError(
                     f"\n'{backend.__name__}.{table_name}' does not correctly implement the"
                     f" contract for '{cls.__name__}'\n\n"
-                    f"Column {column} is defined with an invalid type.\n\n"
+                    f"Column {column} is defined with an invalid type '{backend_column_type}'.\n\n"
                     f"Allowed types are: {', '.join(allowed_types)}"
                 )

--- a/cohortextractor/concepts/table_contract.py
+++ b/cohortextractor/concepts/table_contract.py
@@ -33,3 +33,15 @@ class TableContract:
                 f" contract for '{cls.__name__}'\n\n"
                 f"Missing columns: {', '.join(missing_columns)}"
             )
+        backend_table = getattr(backend, table_name)
+        for column in cls.columns:
+            backend_column_type = backend_table.columns[column].type
+            contract_column_type = cls.columns[column].type
+
+            if backend_column_type not in contract_column_type.allowed_backend_types:
+                raise BackendContractError(
+                    f"\n'{backend.__name__}.{table_name}' does not correctly implement the"
+                    f" contract for '{cls.__name__}'\n\n"
+                    f"Column {column} is defined with an invalid type.\n\n"
+                    f"Allowed types are: {', '.join( contract_column_type.allowed_backend_types)}"
+                )

--- a/cohortextractor/concepts/table_contract.py
+++ b/cohortextractor/concepts/table_contract.py
@@ -37,11 +37,15 @@ class TableContract:
         for column in cls.columns:
             backend_column_type = backend_table.columns[column].type
             contract_column_type = cls.columns[column].type
+            allowed_types = [
+                allowed_type.name
+                for allowed_type in contract_column_type.allowed_backend_types
+            ]
 
-            if backend_column_type not in contract_column_type.allowed_backend_types:
+            if backend_column_type not in allowed_types:
                 raise BackendContractError(
                     f"\n'{backend.__name__}.{table_name}' does not correctly implement the"
                     f" contract for '{cls.__name__}'\n\n"
                     f"Column {column} is defined with an invalid type.\n\n"
-                    f"Allowed types are: {', '.join( contract_column_type.allowed_backend_types)}"
+                    f"Allowed types are: {', '.join(allowed_types)}"
                 )

--- a/cohortextractor/concepts/types.py
+++ b/cohortextractor/concepts/types.py
@@ -1,14 +1,16 @@
+from typing import Protocol
+
 from cohortextractor.sqlalchemy_types import TYPES_BY_NAME
 
 
-class BaseType:
+class BaseType(Protocol):
     """
     Base class for Column types defined in a Contract
     """
 
     # Subclasses must specify the backend Column types that they allow, as
     # tuples of one or more keys from cohortextractor.sqlalchemy_types.TYPES_BY_NAME
-    allowed_backend_types: tuple[TYPES_BY_NAME, ...] = NotImplemented
+    allowed_backend_types: tuple[TYPES_BY_NAME, ...]
 
 
 class PseudoPatientId(BaseType):

--- a/cohortextractor/concepts/types.py
+++ b/cohortextractor/concepts/types.py
@@ -1,15 +1,31 @@
 class BaseType:
-    pass
+    """
+    Base class for Column types defined in a Contract
+    """
+
+    # Subclasses must specify the backend Column types that they allow, as
+    # tuples of one or more keys from cohortextractor.sqlalchemy_types.TYPES_BY_NAME
+    allowed_backend_types: tuple = NotImplemented
 
 
 class PseudoPatientId(BaseType):
-    pass
+    """A type representing a pseudonymised patient ID"""
+
+    allowed_backend_types = ("integer", "varchar")
 
 
 class Date(BaseType):
-    pass
+    """A type representing a date"""
+
+    allowed_backend_types = ("date",)
 
 
 class Choice(BaseType):
+    """
+    A type which restricts column values to a limited set of choices.
+    """
+
+    allowed_backend_types = ("integer", "varchar")
+
     def __init__(self, *choices):
         self.choices = choices

--- a/cohortextractor/concepts/types.py
+++ b/cohortextractor/concepts/types.py
@@ -1,3 +1,6 @@
+from cohortextractor.sqlalchemy_types import TYPES_BY_NAME
+
+
 class BaseType:
     """
     Base class for Column types defined in a Contract
@@ -5,19 +8,19 @@ class BaseType:
 
     # Subclasses must specify the backend Column types that they allow, as
     # tuples of one or more keys from cohortextractor.sqlalchemy_types.TYPES_BY_NAME
-    allowed_backend_types: tuple = NotImplemented
+    allowed_backend_types: tuple[TYPES_BY_NAME, ...] = NotImplemented
 
 
 class PseudoPatientId(BaseType):
     """A type representing a pseudonymised patient ID"""
 
-    allowed_backend_types = ("integer", "varchar")
+    allowed_backend_types = (TYPES_BY_NAME.integer, TYPES_BY_NAME.varchar)
 
 
 class Date(BaseType):
     """A type representing a date"""
 
-    allowed_backend_types = ("date",)
+    allowed_backend_types = (TYPES_BY_NAME.date,)
 
 
 class Choice(BaseType):
@@ -25,7 +28,7 @@ class Choice(BaseType):
     A type which restricts column values to a limited set of choices.
     """
 
-    allowed_backend_types = ("integer", "varchar")
+    allowed_backend_types = (TYPES_BY_NAME.integer, TYPES_BY_NAME.varchar)
 
     def __init__(self, *choices):
         self.choices = choices

--- a/cohortextractor/sqlalchemy_types.py
+++ b/cohortextractor/sqlalchemy_types.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 import sqlalchemy.types
 from sqlalchemy.types import Boolean, Float, Integer, String, Text
 
@@ -41,12 +43,15 @@ class DateTime(sqlalchemy.types.TypeDecorator):
     cache_ok = True
 
 
-TYPES_BY_NAME = {
-    "boolean": Boolean,
-    "date": Date,
-    "datetime": DateTime,
-    "float": Float,
-    "integer": Integer,
-    "varchar": Text,
-    "code": Text,
-}
+TYPES_BY_NAME = Enum(
+    "TYPES_BY_NAME",
+    {
+        "boolean": Boolean,
+        "date": Date,
+        "datetime": DateTime,
+        "float": Float,
+        "integer": Integer,
+        "varchar": Text,
+        "code": Text,
+    },
+)

--- a/tests/concepts/test_table_contract.py
+++ b/tests/concepts/test_table_contract.py
@@ -59,7 +59,7 @@ def test_basic_validation_for_patients_contract_column_types():
     # Unhappy path
     with pytest.raises(
         BackendContractError,
-        match="Column date_of_birth is defined with an invalid type.\n\nAllowed types are: date",
+        match="Column date_of_birth is defined with an invalid type 'integer'.\n\nAllowed types are: date",
     ):
 
         class BadBackend(BaseBackend):

--- a/tests/concepts/test_table_contract.py
+++ b/tests/concepts/test_table_contract.py
@@ -47,3 +47,31 @@ def test_basic_validation_that_table_implements_patients_contract():
         )
 
     assert GoodBackend("db://")
+
+
+def test_basic_validation_for_patients_contract_column_types():
+    # Basic table contract
+    class PatientsContract(TableContract):
+        patient_id = ColumnContract(type=types.PseudoPatientId(), help="")
+        date_of_birth = ColumnContract(type=types.Date(), help="")
+        sex = ColumnContract(type=types.Choice("F", "M"), help="")
+
+    # Unhappy path
+    with pytest.raises(
+        BackendContractError,
+        match="Column date_of_birth is defined with an invalid type.\n\nAllowed types are: date",
+    ):
+
+        class BadBackend(BaseBackend):
+            backend_id = "bad_test_backend"
+            query_engine_class = BaseSQLQueryEngine
+            patient_join_column = "patient_id"
+
+            patients = MappedTable(
+                implements=PatientsContract,
+                source="Patient",
+                columns=dict(
+                    date_of_birth=Column("integer", source="DateOfBirth"),
+                    sex=Column("varchar", source="Sex"),
+                ),
+            )


### PR DESCRIPTION
Adds type-checking for columns in a table contract against a backend, allowing for more than one acceptable type if necessary.

It does this simply by adding an `allowed_backend_types`  attribute to each type in `concepts.types`, which is a tuple of one or more keys from `sqlalchemy_types.TYPES_BY_NAME`.   `sqlalchemy_types.TYPES_BY_NAME` maps type names in a backend to sqlalchemy types.  The individual query engine dialects deal with custom handling of built in types, so we  should only need to check that the name mapping is correct here.