### PR TITLE
Re-revert Packaging with Fixed Version Number

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,31 @@
+name: Build and publish image
+
+on:
+  create:
+  workflow_dispatch:
+
+jobs:
+  build-and-publish-docker-image:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    env:
+      image: ghcr.io/opensafely-core/cohortextractor-v2
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get current git tag
+        id: tags
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag ${{ env.image }}:latest
+
+      - name: Log into GitHub Container Registry
+        run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
+
+      - name: Push image to GitHub Container Registry
+        env:
+          VERSION: ${{ steps.tags.outputs.tag }}
+        run: |
+          docker tag ${{ env.image }} ${{ env.image }}:$VERSION
+          docker push ${{ env.image }}:$VERSION

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,17 +43,28 @@ jobs:
         with:
           failure-threshold: error
 
-  docker-publish:
-    if: github.ref == 'refs/heads/main'
+  tag-new-version:
+    # This uses `conventional commits` to generate tags.  A full list
+    # of valid prefixes is here:
+    # https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+    #
+    # fix, perf -> patch release
+    # feat -> minor release
+    # BREAKING CHANGE in footer -> major release
+    #
+    # anything else (docs, refactor, etc) does not create a release
+    needs: [test]
     runs-on: ubuntu-latest
-    needs: [test, lint-dockerfile]
-    env:
-      image: ghcr.io/opensafely-core/cohortextractor-v2:latest
+    outputs:
+      tag: ${{ steps.tag.outputs.new_version }}
     steps:
       - uses: actions/checkout@v2
-      - name: Build image
-        run: docker build . --file Dockerfile --tag ${{ env.image }}
-      - name: Log into GitHub Container Registry
-        run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
-      - name: Push image to GitHub Container Registry
-        run: docker push ${{ env.image }}
+        with:
+          fetch-depth: 0
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@981ffb2cc3f2b684b2bfd8ee17bc8d781368ba60
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          release_branches: main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "cohortextractor"
 description = ""
-version = "2.0.0"
+version = "not-a-package"
 readme = "README.md"
 authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "cohortextractor"
 description = ""
-version = "not-a-package"
+version = "2+local"
 readme = "README.md"
 authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
 license = {file = "LICENSE"}

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -4,8 +4,8 @@
 # To generate a requirements file that includes both prod and dev requirements, run:
 # pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 
-pre-commit
 black
+docker
 flake8
 flake8-builtins
 flake8-implicit-str-concat
@@ -14,11 +14,12 @@ interrogate
 isort
 mypy
 pandas-stubs
+pip-tools
+pre-commit
 pytest
 pytest-cov
 pytest-freezegun
 pytest-mock
 pyupgrade
-sqlalchemy-stubs
-docker
 six # undeclared dependency of docker (https://github.com/docker/docker-py/issues/2842)
+sqlalchemy-stubs

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -37,6 +37,7 @@ click==8.0.3 \
     # via
     #   black
     #   interrogate
+    #   pip-tools
 colorama==0.4.4 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2
@@ -188,6 +189,14 @@ pathspec==0.9.0 \
     --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
     --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
     # via black
+pep517==0.12.0 \
+    --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
+    --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
+    # via pip-tools
+pip-tools==6.4.0 \
+    --hash=sha256:65553a15b1ba34be5e43889345062e38fb9b219ffa23b084ca0d4c4039b6f53b \
+    --hash=sha256:bb2c3272bc229b4a6d25230ebe255823aba1aa466a0d698c48ab7eb5ab7efdc9
+    # via -r requirements.dev.in
 platformdirs==2.4.0 \
     --hash=sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2 \
     --hash=sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d
@@ -362,6 +371,7 @@ tomli==1.2.1 \
     # via
     #   black
     #   coverage
+    #   pep517
 typing-extensions==3.10.0.2 \
     --hash=sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e \
     --hash=sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7 \
@@ -382,3 +392,17 @@ websocket-client==1.2.1 \
     --hash=sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec \
     --hash=sha256:8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d
     # via docker
+wheel==0.37.0 \
+    --hash=sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd \
+    --hash=sha256:e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad
+    # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==21.3.1 \
+    --hash=sha256:deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d \
+    --hash=sha256:fd11ba3d0fdb4c07fbc5ecbba0b1b719809420f25038f8ee3cd913d3faa3033a
+    # via pip-tools
+setuptools==59.2.0 \
+    --hash=sha256:157d21de9d055ab9e8ea3186d91e7f4f865e11f42deafa952d90842671fc2576 \
+    --hash=sha256:4adde3d1e1c89bde1c643c64d89cdd94cbfd8c75252ee459d4500bccb9c7d05d
+    # via pip-tools


### PR DESCRIPTION
Something deep inside the packaging stack (in pep517 specifically) was very unhappy with a non-pep440 compliant version string, so this flips it to a minimally useful [local version identifier](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers) along with reverting the removal of all the related bits.