### PR TITLE
Report Line Coverage

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -145,5 +145,10 @@ test-all *ARGS: devenv build-cohort-extractor
     set -euo pipefail
 
     [[ -v CI ]] && echo "::group::Run tests (click to view)" || echo "Run tests"
-    $BIN/python -m pytest --cov=cohortextractor2 --cov=tests {{ ARGS }}
+    $BIN/python -m pytest \
+        --cov=cohortextractor2 \
+        --cov=tests \
+        --cov-report=html \
+        --cov-report=term-missing:skip-covered \
+        {{ ARGS }}
     [[ -v CI ]]  && echo "::endgroup::" || echo ""

--- a/Justfile
+++ b/Justfile
@@ -150,5 +150,6 @@ test-all *ARGS: devenv build-cohort-extractor
         --cov=tests \
         --cov-report=html \
         --cov-report=term-missing:skip-covered \
+        tests \
         {{ ARGS }}
     [[ -v CI ]]  && echo "::endgroup::" || echo ""


### PR DESCRIPTION
This generates the HTML report when running coverage and adds missing line ranges to the terminal output so we get the best of both worlds.  It also sets the test location explicity, which isn't completely necessary but probably saves pytest a few cpu cycles and makes it obvious where we expect tests to be.