### PR TITLE
Implement the patient demographics contract

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,8 @@ export COMPILE := BIN + "/pip-compile --allow-unsafe --generate-hashes"
 
 alias help := list
 
+test_args := "tests"
+
 # list available commands
 list:
     @just --list
@@ -124,7 +126,7 @@ connect-to-persistent-database:
     docker exec -it cohort-extractor-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'Your_password123!'
 
 # Full set of tests run by CI
-test *ARGS:
+test *ARGS=test_args:
     just test-all {{ ARGS }}
 
 # run the unit tests only. Optional args are passed to pytest
@@ -140,7 +142,7 @@ test-smoke *ARGS: devenv build-cohort-extractor
     $BIN/python -m pytest -m smoke {{ ARGS }}
 
 # run all tests including integration and smoke tests. Optional args are passed to pytest
-test-all *ARGS: devenv build-cohort-extractor
+test-all *ARGS=test_args: devenv build-cohort-extractor
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/Justfile
+++ b/Justfile
@@ -150,6 +150,5 @@ test-all *ARGS: devenv build-cohort-extractor
         --cov=tests \
         --cov-report=html \
         --cov-report=term-missing:skip-covered \
-        tests \
         {{ ARGS }}
     [[ -v CI ]]  && echo "::endgroup::" || echo ""

--- a/cohortextractor2/backends/tpp.py
+++ b/cohortextractor2/backends/tpp.py
@@ -71,10 +71,12 @@ class TPPBackend(BaseBackend):
         columns=dict(
             sex=Column("varchar"),
             date_of_birth=Column("date"),
+            date_of_death=Column("date"),
         ),
         query="""
             SELECT  Patient_ID as patient_id,
                 datefromparts(year(DateOfBirth), month(DateOfBirth), 1) as date_of_birth,
+                datefromparts(year(DateOfDeath), month(DateOfDeath), 1) as date_of_death,
                 CASE
                     WHEN Sex = 'M' THEN 'male'
                     WHEN Sex = 'F' THEN 'female'

--- a/cohortextractor2/backends/tpp.py
+++ b/cohortextractor2/backends/tpp.py
@@ -76,7 +76,11 @@ class TPPBackend(BaseBackend):
         query="""
             SELECT  Patient_ID as patient_id,
                 DateOfBirth as date_of_birth,
-                datefromparts(year(DateOfDeath), month(DateOfDeath), 1) as date_of_death,
+                CASE
+                    WHEN DateOfDeath = '9999-12-31' THEN NULL
+                    ELSE
+                        datefromparts(year(DateOfDeath), month(DateOfDeath), 1)
+                    END as date_of_death,
                 CASE
                     WHEN Sex = 'M' THEN 'male'
                     WHEN Sex = 'F' THEN 'female'

--- a/cohortextractor2/backends/tpp.py
+++ b/cohortextractor2/backends/tpp.py
@@ -59,12 +59,30 @@ class TPPBackend(BaseBackend):
     patient_join_column = "Patient_ID"
 
     patients = MappedTable(
-        implements=tables.Patients,
         source="Patient",
         columns=dict(
             sex=Column("varchar", source="Sex"),
             date_of_birth=Column("date", source="DateOfBirth"),
         ),
+    )
+
+    patient_demographics = QueryTable(
+        implements=tables.PatientDemographics,
+        columns=dict(
+            sex=Column("varchar"),
+            date_of_birth=Column("date"),
+        ),
+        query="""
+            SELECT  Patient_ID as patient_id,
+                datefromparts(year(DateOfBirth), month(DateOfBirth), 1) as date_of_birth,
+                CASE
+                    WHEN Sex = 'M' THEN 'male'
+                    WHEN Sex = 'F' THEN 'female'
+                    WHEN Sex = 'I' THEN 'intersex'
+                    ELSE 'unknown'
+                END as sex
+            FROM Patient
+        """,
     )
 
     clinical_events = QueryTable(

--- a/cohortextractor2/backends/tpp.py
+++ b/cohortextractor2/backends/tpp.py
@@ -75,7 +75,7 @@ class TPPBackend(BaseBackend):
         ),
         query="""
             SELECT  Patient_ID as patient_id,
-                datefromparts(year(DateOfBirth), month(DateOfBirth), 1) as date_of_birth,
+                DateOfBirth as date_of_birth,
                 datefromparts(year(DateOfDeath), month(DateOfDeath), 1) as date_of_death,
                 CASE
                     WHEN Sex = 'M' THEN 'male'

--- a/cohortextractor2/concepts/constraints.py
+++ b/cohortextractor2/concepts/constraints.py
@@ -1,0 +1,28 @@
+class BaseConstraint:
+    """
+    Base class for Constraints to be enforced on Columns defined in a Contract
+    """
+
+
+class ChoiceConstraint(BaseConstraint):
+    """
+    Defines a constraint on a choices Column to ensure data matches the allowed options
+    """
+
+    def __init__(self, *choices):
+        self.choices = choices
+
+
+class DateConstraint(BaseConstraint):
+    """
+    Defines a constraint on a date Column to ensure it conforms to required date format(s)
+    """
+
+    base_format = "%Y-%m-%d"
+
+    def __init__(self, match_format: str):
+        """
+        match_format: str.  A constraint format in the form '%Y-%m-%d' to compare with the base format.
+        e.g. '%Y-%m-01' ensures that each date in the backend column repesents the 1st of a month
+        """
+        self.match_format = match_format

--- a/cohortextractor2/concepts/constraints.py
+++ b/cohortextractor2/concepts/constraints.py
@@ -3,6 +3,10 @@ class BaseConstraint:
     Base class for Constraints to be enforced on Columns defined in a Contract
     """
 
+    def validate(self, database):
+        """Validate against data"""
+        raise NotImplementedError
+
 
 class ChoiceConstraint(BaseConstraint):
     """
@@ -11,6 +15,10 @@ class ChoiceConstraint(BaseConstraint):
 
     def __init__(self, *choices):
         self.choices = choices
+
+    def validate(self, backend_table, column):
+        """Validate against data"""
+        # TODO
 
 
 class DateConstraint(BaseConstraint):
@@ -26,3 +34,9 @@ class DateConstraint(BaseConstraint):
         e.g. '%Y-%m-01' ensures that each date in the backend column repesents the 1st of a month
         """
         self.match_format = match_format
+
+    def validate(self, backend_table, column):
+        """Validate against data"""
+        # TODO
+        # Compare column value (a python date object) formatted with base_format and match_format
+        # to ensure they match

--- a/cohortextractor2/concepts/constraints.py
+++ b/cohortextractor2/concepts/constraints.py
@@ -41,22 +41,11 @@ class UniqueConstraint(BaseConstraint):
         # TODO
 
 
-class DateConstraint(BaseConstraint):
+class FirstOfMonthConstraint(BaseConstraint):
     """
-    Defines a constraint on a date Column to ensure it conforms to required date format(s)
+    Defines a constraint on a date Column to ensure the day is always the first of the month
     """
-
-    base_format = "%Y-%m-%d"
-
-    def __init__(self, match_format: str):
-        """
-        match_format: str.  A constraint format in the form '%Y-%m-%d' to compare with the base format.
-        e.g. '%Y-%m-01' ensures that each date in the backend column repesents the 1st of a month
-        """
-        self.match_format = match_format
 
     def validate(self, backend_table, column):
         """Validate against data"""
         # TODO
-        # Compare column value (a python date object) formatted with base_format and match_format
-        # to ensure they match

--- a/cohortextractor2/concepts/constraints.py
+++ b/cohortextractor2/concepts/constraints.py
@@ -21,6 +21,26 @@ class ChoiceConstraint(BaseConstraint):
         # TODO
 
 
+class NotNullConstraint(BaseConstraint):
+    """
+    Defines a constraint on a Column to ensure no null values
+    """
+
+    def validate(self, backend_table, column):
+        """Validate values exist for all rows in column"""
+        # TODO
+
+
+class UniqueConstraint(BaseConstraint):
+    """
+    Defines a constraint on a Column to ensure values are unique
+    """
+
+    def validate(self, backend_table, column):
+        """Validate no duplicated values"""
+        # TODO
+
+
 class DateConstraint(BaseConstraint):
     """
     Defines a constraint on a date Column to ensure it conforms to required date format(s)

--- a/cohortextractor2/concepts/table_contract.py
+++ b/cohortextractor2/concepts/table_contract.py
@@ -9,6 +9,7 @@ class Column:
 
     type: BaseType  # noqa: A003
     description: str  # noqa: A003
+    help: str  # noqa: A003
     constraints: list[BaseConstraint]  # noqa: A003
 
 
@@ -51,3 +52,11 @@ class TableContract:
                     f"Column {column} is defined with an invalid type '{backend_column_type}'.\n\n"
                     f"Allowed types are: {', '.join(allowed_types)}"
                 )
+
+    @classmethod
+    def validate_data(cls, backend, table_name):
+        """Validate backend data against any column constraints defined in the table contract"""
+        backend_table = getattr(backend, table_name)
+        for column in cls.columns:
+            for constraint in cls.columns[column].constraints:
+                constraint.validate(backend_table, column)

--- a/cohortextractor2/concepts/table_contract.py
+++ b/cohortextractor2/concepts/table_contract.py
@@ -1,5 +1,6 @@
 import dataclasses
 
+from .constraints import BaseConstraint
 from .types import BaseType
 
 
@@ -7,7 +8,8 @@ from .types import BaseType
 class Column:
 
     type: BaseType  # noqa: A003
-    help: str  # noqa: A003
+    description: str  # noqa: A003
+    constraints: list[BaseConstraint]  # noqa: A003
 
 
 class BackendContractError(Exception):

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -1,6 +1,7 @@
 from ..dsl import EventFrame
 from ..query_language import Table
 from . import types
+from .constraints import ChoiceConstraint, DateConstraint
 from .table_contract import Column, TableContract
 
 
@@ -21,30 +22,35 @@ class PracticeRegistrations(EventFrame):
         super().__init__(Table("practice_registrations"))
 
 
-class Patients(TableContract):
+class PatientDemographics(TableContract):
     """
-    The Patients table holds personal details about the patient.
+    Provides demographic information about patients
     """
 
     patient_id = Column(
         type=types.PseudoPatientId(),
-        help=(
+        description=(
             "Patient's pseudonymous identifier, for linkage. You should not normally "
             "output or operate on this column"
         ),
+        constraints=[],
     )
     date_of_birth = Column(
         type=types.Date(),
-        help="The patient's date of birth",
+        description="Patient's year and month of birth.  The day will always be the first of the month. Must be present.",
+        constraints=[DateConstraint(match_format=["%Y-%m-01"])],
     )
     sex = Column(
-        type=types.Choice("F", "M"),
-        help="The patient's sex",
+        type=types.Choice("female", "male", "intersex", "unknown"),
+        description="Patient's sex.  One of male, female, intersex or unknown (the last covers all other options,"
+        "including but not limited to “rather not say” and empty/missing values). "
+        "Must be present.",
+        constraints=[ChoiceConstraint()],
     )
 
 
 clinical_events = ClinicalEvents()
-patients = Patients()
+patients = PatientDemographics()
 registrations = PracticeRegistrations()
 
 # Stubs

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -1,7 +1,7 @@
 from ..dsl import EventFrame
 from ..query_language import Table
 from . import types
-from .constraints import DateConstraint, NotNullConstraint, UniqueConstraint
+from .constraints import FirstOfMonthConstraint, NotNullConstraint, UniqueConstraint
 from .table_contract import Column, TableContract
 
 
@@ -40,7 +40,7 @@ class PatientDemographics(TableContract):
         type=types.Date(),
         description="Patient's year and month of birth.",
         help="The day will always be the first of the month. Must be present.",
-        constraints=[NotNullConstraint(), DateConstraint(match_format=["%Y-%m-01"])],
+        constraints=[NotNullConstraint(), FirstOfMonthConstraint()],
     )
     sex = Column(
         type=types.Choice("female", "male", "intersex", "unknown"),

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -33,18 +33,23 @@ class PatientDemographics(TableContract):
             "Patient's pseudonymous identifier, for linkage. You should not normally "
             "output or operate on this column"
         ),
+        help="",
         constraints=[],
     )
     date_of_birth = Column(
         type=types.Date(),
-        description="Patient's year and month of birth.  The day will always be the first of the month. Must be present.",
+        description="Patient's year and month of birth.",
+        help="The day will always be the first of the month. Must be present.",
         constraints=[DateConstraint(match_format=["%Y-%m-01"])],
     )
     sex = Column(
         type=types.Choice("female", "male", "intersex", "unknown"),
-        description="Patient's sex.  One of male, female, intersex or unknown (the last covers all other options,"
-        "including but not limited to “rather not say” and empty/missing values). "
-        "Must be present.",
+        description="Patient's sex.",
+        help=(
+            "One of male, female, intersex or unknown (the last covers all other options,"
+            "including but not limited to 'rather not say' and empty/missing values). "
+            "Must be present."
+        ),
         constraints=[ChoiceConstraint()],
     )
 

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -38,7 +38,7 @@ class PatientDemographics(TableContract):
     )
     date_of_birth = Column(
         type=types.Date(),
-        description="Patient's year and month of birth.",
+        description="Patient's year and month of birth, provided in format YYYY-MM-01.",
         help="The day will always be the first of the month. Must be present.",
         constraints=[NotNullConstraint(), FirstOfMonthConstraint()],
     )
@@ -51,6 +51,12 @@ class PatientDemographics(TableContract):
             "Must be present."
         ),
         constraints=[NotNullConstraint()],
+    )
+    date_of_death = Column(
+        type=types.Date(),
+        description="Patient's year and month of death, provided in format YYYY-MM-01.",
+        help="The day will always be the first of the month.",
+        constraints=[FirstOfMonthConstraint()],
     )
 
 

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -1,7 +1,7 @@
 from ..dsl import EventFrame
 from ..query_language import Table
 from . import types
-from .constraints import ChoiceConstraint, DateConstraint
+from .constraints import DateConstraint
 from .table_contract import Column, TableContract
 
 
@@ -34,7 +34,6 @@ class PatientDemographics(TableContract):
             "output or operate on this column"
         ),
         help="",
-        constraints=[],
     )
     date_of_birth = Column(
         type=types.Date(),
@@ -50,7 +49,6 @@ class PatientDemographics(TableContract):
             "including but not limited to 'rather not say' and empty/missing values). "
             "Must be present."
         ),
-        constraints=[ChoiceConstraint()],
     )
 
 

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -1,7 +1,7 @@
 from ..dsl import EventFrame
 from ..query_language import Table
 from . import types
-from .constraints import DateConstraint
+from .constraints import DateConstraint, NotNullConstraint, UniqueConstraint
 from .table_contract import Column, TableContract
 
 
@@ -34,12 +34,13 @@ class PatientDemographics(TableContract):
             "output or operate on this column"
         ),
         help="",
+        constraints=[NotNullConstraint(), UniqueConstraint()],
     )
     date_of_birth = Column(
         type=types.Date(),
         description="Patient's year and month of birth.",
         help="The day will always be the first of the month. Must be present.",
-        constraints=[DateConstraint(match_format=["%Y-%m-01"])],
+        constraints=[NotNullConstraint(), DateConstraint(match_format=["%Y-%m-01"])],
     )
     sex = Column(
         type=types.Choice("female", "male", "intersex", "unknown"),
@@ -49,6 +50,7 @@ class PatientDemographics(TableContract):
             "including but not limited to 'rather not say' and empty/missing values). "
             "Must be present."
         ),
+        constraints=[NotNullConstraint()],
     )
 
 

--- a/tests/backends/test_tpp.py
+++ b/tests/backends/test_tpp.py
@@ -425,10 +425,10 @@ def test_clinical_events_table_multiple_codes(database):
 def test_patients_contract_table(database):
     database.setup(
         patient(1, "M", "1990-01-01", date_of_death="2021-01-04"),
-        patient(2, "F", "1990-01-10", date_of_death="2020-02-04"),
-        patient(3, "I", "1990-01-02"),
-        patient(4, None, "1990-01-03"),
-        patient(5, "X", "1990-01-04"),
+        patient(2, "F", "1990-01-01", date_of_death="2020-02-04"),
+        patient(3, "I", "1990-01-01"),
+        patient(4, None, "1990-01-01"),
+        patient(5, "X", "1990-01-01"),
     )
 
     query = TPPBackend.patient_demographics.get_query()

--- a/tests/backends/test_tpp.py
+++ b/tests/backends/test_tpp.py
@@ -426,7 +426,7 @@ def test_patients_contract_table(database):
     database.setup(
         patient(1, "M", "1990-01-01", date_of_death="2021-01-04"),
         patient(2, "F", "1990-01-01", date_of_death="2020-02-04"),
-        patient(3, "I", "1990-01-01"),
+        patient(3, "I", "1990-01-01", date_of_death="9999-12-31"),
         patient(4, None, "1990-01-01"),
         patient(5, "X", "1990-01-01"),
     )

--- a/tests/backends/test_tpp.py
+++ b/tests/backends/test_tpp.py
@@ -424,8 +424,8 @@ def test_clinical_events_table_multiple_codes(database):
 @pytest.mark.integration
 def test_patients_contract_table(database):
     database.setup(
-        patient(1, "M", "1990-01-01"),
-        patient(2, "F", "1990-01-10"),
+        patient(1, "M", "1990-01-01", date_of_death="2021-01-04"),
+        patient(2, "F", "1990-01-10", date_of_death="2020-02-04"),
         patient(3, "I", "1990-01-02"),
         patient(4, None, "1990-01-03"),
         patient(5, "X", "1990-01-04"),
@@ -434,11 +434,10 @@ def test_patients_contract_table(database):
     query = TPPBackend.patient_demographics.get_query()
 
     results = list(run_query(database, query))
-
     assert results == [
-        (1, date(1990, 1, 1), "male"),
-        (2, date(1990, 1, 1), "female"),
-        (3, date(1990, 1, 1), "intersex"),
-        (4, date(1990, 1, 1), "unknown"),
-        (5, date(1990, 1, 1), "unknown"),
+        (1, date(1990, 1, 1), date(2021, 1, 1), "male"),
+        (2, date(1990, 1, 1), date(2020, 2, 1), "female"),
+        (3, date(1990, 1, 1), None, "intersex"),
+        (4, date(1990, 1, 1), None, "unknown"),
+        (5, date(1990, 1, 1), None, "unknown"),
     ]

--- a/tests/concepts/test_table_contract.py
+++ b/tests/concepts/test_table_contract.py
@@ -8,6 +8,8 @@ from cohortextractor2.concepts.table_contract import Column as ColumnContract
 from cohortextractor2.concepts.table_contract import TableContract
 from cohortextractor2.query_engines.base_sql import BaseSQLQueryEngine
 
+from ..lib.mock_backend import patient
+
 
 def test_basic_validation_that_table_implements_patients_contract():
     # Basic table contract
@@ -90,7 +92,16 @@ def test_basic_validation_for_patients_contract_column_types():
             )
 
 
-def test_basic_validation_for_patients_contract_column_constraints():
+def test_basic_validation_for_patients_contract_column_constraints(engine):
+    engine.setup(
+        patient(
+            1,
+            dob="1990-01-01",
+        ),
+        patient(2, dob="1991-02-01"),
+        patient(3, dob="1992-03-01", sex="X"),
+    )
+
     # Basic table contract
     class PatientsContract(TableContract):
         patient_id = ColumnContract(
@@ -121,6 +132,6 @@ def test_basic_validation_for_patients_contract_column_constraints():
             ),
         )
 
-    assert PatientsContract().validate_data(
-        GoodBackend(database_url=None), "patients", "sex"
-    )
+    backend = GoodBackend(database_url=engine.database.host_url())
+    comment = "Note: This test is expected to fail when TableContract.validate_data is implemented"
+    assert PatientsContract.validate_data(backend, "patients") is None, comment

--- a/tests/concepts/test_table_contract.py
+++ b/tests/concepts/test_table_contract.py
@@ -11,9 +11,15 @@ from cohortextractor2.query_engines.base_sql import BaseSQLQueryEngine
 def test_basic_validation_that_table_implements_patients_contract():
     # Basic table contract
     class PatientsContract(TableContract):
-        patient_id = ColumnContract(type=types.PseudoPatientId(), help="")
-        date_of_birth = ColumnContract(type=types.Date(), help="")
-        sex = ColumnContract(type=types.Choice("F", "M"), help="")
+        patient_id = ColumnContract(
+            type=types.PseudoPatientId(), description="", constraints=[]
+        )
+        date_of_birth = ColumnContract(
+            type=types.Date(), description="", constraints=[]
+        )
+        sex = ColumnContract(
+            type=types.Choice("F", "M"), description="", constraints=[]
+        )
 
     # Unhappy path
     with pytest.raises(BackendContractError, match="Missing columns: sex"):
@@ -52,9 +58,15 @@ def test_basic_validation_that_table_implements_patients_contract():
 def test_basic_validation_for_patients_contract_column_types():
     # Basic table contract
     class PatientsContract(TableContract):
-        patient_id = ColumnContract(type=types.PseudoPatientId(), help="")
-        date_of_birth = ColumnContract(type=types.Date(), help="")
-        sex = ColumnContract(type=types.Choice("F", "M"), help="")
+        patient_id = ColumnContract(
+            type=types.PseudoPatientId(), description="", constraints=[]
+        )
+        date_of_birth = ColumnContract(
+            type=types.Date(), description="", constraints=[]
+        )
+        sex = ColumnContract(
+            type=types.Choice("F", "M"), description="", constraints=[]
+        )
 
     # Unhappy path
     with pytest.raises(

--- a/tests/lib/mock_backend.py
+++ b/tests/lib/mock_backend.py
@@ -23,6 +23,7 @@ def backend_factory(query_engine_cls):
             columns=dict(
                 height=Column("float", source="Height"),
                 date_of_birth=Column("date", source="DateOfBirth"),
+                sex=Column("varchar", source="Sex"),
             ),
         )
         practice_registrations = MappedTable(
@@ -128,9 +129,10 @@ class Patients(Base):
     PatientId = sqlalchemy.Column(sqlalchemy.Integer, default=null)
     Height = sqlalchemy.Column(sqlalchemy.Float, default=null)
     DateOfBirth = sqlalchemy.Column(sqlalchemy.Date, default=null)
+    Sex = sqlalchemy.Column(sqlalchemy.Text, default=null)
 
 
-def patient(patient_id, *entities, height=None, dob=None):
+def patient(patient_id, *entities, height=None, dob=None, sex="M"):
     entities = list(entities)
     # add a default RegistrationHistory entry
     entities.append(RegistrationHistory(StartDate="1900-01-01", EndDate="2999-12-31"))

--- a/tests/lib/tpp_schema.py
+++ b/tests/lib/tpp_schema.py
@@ -9,12 +9,18 @@ class Patient(Base):
     Patient_ID = Column(Integer, primary_key=True)
     Sex = Column(String())
     DateOfBirth = Column(Date)
+    DateOfDeath = Column(Date)
 
 
-def patient(patient_id, sex, dob, *entities):
+def patient(patient_id, sex, dob, *entities, date_of_death=None):
     for entity in entities:
         entity.Patient_ID = patient_id
-    return [Patient(Patient_ID=patient_id, Sex=sex, DateOfBirth=dob), *entities]
+    return [
+        Patient(
+            Patient_ID=patient_id, Sex=sex, DateOfBirth=dob, DateOfDeath=date_of_death
+        ),
+        *entities,
+    ]
 
 
 class Organisation(Base):

--- a/tests/lib/util.py
+++ b/tests/lib/util.py
@@ -40,5 +40,5 @@ def iter_flatten(iterable, iter_classes=(list, tuple)):
 
 class OldCohortWithPopulation:
     def __init_subclass__(cls):
-        if not hasattr(cls, "population"):
+        if not hasattr(cls, "population"):  # pragma: no cover
             cls.population = table("practice_registrations").exists()


### PR DESCRIPTION
This PR updates the Patient table contract to reflect the real contract, with column constraints, and adds a `patient_demographics` table for the TPP backend which implements this contract.

Also adds a Constraint class, with the beginnings of a method for validating the data in backend databases based on those constraints.