### PR TITLE
Support for connecting to real Databricks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,5 @@ ignore = \
     W503 \ # line break before binary operator (black disagrees)
     E203   # whitespace before ':' (black disagrees)
 max-line-length = 88
+per-file-ignores =
+    scripts/dbx:INP001

--- a/.github/workflows/databricks.yml
+++ b/.github/workflows/databricks.yml
@@ -1,0 +1,34 @@
+---
+name: Databricks CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_args:
+        description: "Tests to run or other pytest args"
+        required: true
+        default: "tests/backend/test_databricks.py"
+
+jobs:
+  test:
+    needs: [check]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+      - uses: extractions/setup-just@v1
+      - name: Login to databricks
+        run: |
+            echo <<< EOF > ~/.databrickscfg
+            [DEFAULT]
+            host = https://community.cloud.databricks.com:443
+            username = simon.davy@thedatalab.org
+            password = ${{ secrets.DATABRICKS_PASSWORD }}
+            jobs-api-version = 2.0
+            EOF
+      - name: Run Databricks tests
+        run:
+            just databricks-test ${{ github.event.inputs.test_args }}

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -73,3 +73,53 @@ Starting with version 4.0, Bash is licenced under GPLv3. Because of this, macOS 
 ```bash
 brew install bash
 ```
+
+
+## Running tests against Databricks
+
+The test suite for Databricks/Spark backend by default runs tests against
+a local spark db in a container, for reliablility and speed.
+
+Open source Spark and Databricks' Spark are very similar, and this provides
+a good enough tests for the SQL parts of a backend.
+
+However, we still need to run tests against an actual Databricks instance, as
+the way the initial connection is made is different, and potentially other
+things also. We can run the test manually, using a helper script in
+`scripts/dbx` to manage our Databricks instance.
+
+
+### Running locally against Databricks
+
+First you need to set up your Databricks auth.
+
+1. Register for a free account at https://community.cloud.databricks.com/
+
+2. Log in to the databricks CLI tool (which is installed in the venv):
+
+    databricks configure --host https://community.cloud.databricks.com
+
+3. Test it's working with: `databricks clusters list`. If that doesn't error,
+   you are set up.
+
+
+You should then be able to run tests against databricks with:
+
+    just databricks-test [tests/backends/test_databricks.py]
+
+Warning: running the full test suite takes a long time.
+
+Note: This command will ensure there is an active Databricks cluster, and then
+run the tests against it.  Cluster creation is idempotent - if a cluster is
+alread up and running, it will use that. If it has terminated (after 2 hours of
+inactivity), it will delete the old one and create a new one.
+
+For more information about your Databricks cluster, you can use the dbx tool:
+
+    just dbx
+
+    unset DATABRICKS_URL
+
+5. Run the tests you want to run, e.g.
+
+    just test tests/backend/test_databricks.py

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -81,12 +81,17 @@ The test suite for Databricks/Spark backend by default runs tests against
 a local spark db in a container, for reliablility and speed.
 
 Open source Spark and Databricks' Spark are very similar, and this provides
-a good enough tests for the SQL parts of a backend.
+a good enough test basis for the SQL parts of a backend.
 
 However, we still need to run tests against an actual Databricks instance, as
-the way the initial connection is made is different, and potentially other
-things also. We can run the test manually, using a helper script in
-`scripts/dbx` to manage our Databricks instance.
+the way connections are made is different, and potentially more things down the
+line.
+
+Databricks is only only available in SaaS form, and  we use the free Community
+Edition version, but it is limited, slow, and not 100% reliable, so we
+do not run it by default, it needs to be manually run. We use some `just`
+commands and our helper script in `scripts/dbx` to manage a test Databricks
+instance to run the tests against.
 
 
 ### Running locally against Databricks
@@ -118,8 +123,12 @@ For more information about your Databricks cluster, you can use the dbx tool:
 
     just dbx
 
+or
+    ./scripts/dbx
+
+
 ### Running Databricks test in Github CI
 
 You can manually run the tests in github by triggering the "Databricks CI"
-action.  default it will just run the `tests/backends/test_databricks.py`, but
-you can specify different arguments when you trigger it.
+action. By default it will just run the `tests/backends/test_databricks.py`,
+but you can specify different arguments when you trigger it.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -118,8 +118,8 @@ For more information about your Databricks cluster, you can use the dbx tool:
 
     just dbx
 
-    unset DATABRICKS_URL
+### Running Databricks test in Github CI
 
-5. Run the tests you want to run, e.g.
-
-    just test tests/backend/test_databricks.py
+You can manually run the tests in github by triggering the "Databricks CI"
+action.  default it will just run the `tests/backends/test_databricks.py`, but
+you can specify different arguments when you trigger it.

--- a/Justfile
+++ b/Justfile
@@ -152,3 +152,18 @@ test-all *ARGS: devenv build-cohort-extractor
         --cov-report=term-missing:skip-covered \
         {{ ARGS }}
     [[ -v CI ]]  && echo "::endgroup::" || echo ""
+
+# run scripts/dbx
+dbx *ARGS:
+    @$BIN/python scripts/dbx {{ ARGS }}
+
+# ensure a working databricks cluster is set up
+databricks-env: devenv
+    $BIN/python scripts/dbx create --wait --timeout 120
+
+
+databricks-test *ARGS: devenv databricks-env
+    #!/usr/bin/env bash
+    export DATABRICKS_URL="$($BIN/python scripts/dbx url)"
+    echo {{ ARGS }}
+    just test {{ ARGS }}

--- a/Justfile
+++ b/Justfile
@@ -161,7 +161,6 @@ dbx *ARGS:
 databricks-env: devenv
     $BIN/python scripts/dbx create --wait --timeout 120
 
-
 databricks-test *ARGS: devenv databricks-env
     #!/usr/bin/env bash
     export DATABRICKS_URL="$($BIN/python scripts/dbx url)"

--- a/Justfile
+++ b/Justfile
@@ -150,6 +150,5 @@ test-all *ARGS: devenv build-cohort-extractor
         --cov=tests \
         --cov-report=html \
         --cov-report=term-missing:skip-covered \
-        tests \
         {{ ARGS }}
     [[ -v CI ]]  && echo "::endgroup::" || echo ""

--- a/cohortextractor2/query_engines/spark_dialect.py
+++ b/cohortextractor2/query_engines/spark_dialect.py
@@ -28,6 +28,8 @@ class SparkDate(sqlalchemy.types.TypeDecorator):
         # return the expected type here.
         if isinstance(value, datetime.datetime):
             return value.date()
+        elif isinstance(value, datetime.date):
+            return value
         else:
             return sqlalchemy.processors.str_to_date(value)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
   # in `sasl` which we don't need and which causes us installation problems
   # because it doesn't have a wheel and requires the libsasl2 headers to compile.
   "thrift",
+  # Databricks specific connector
+  "databricks-sql-connector",
 ]
 
 [project.scripts]
@@ -118,7 +120,9 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = [
   "pyhive.sqlalchemy_hive.*",
-  "sqlalchemy.dialects.mssql.pymssql"
+  "sqlalchemy.dialects.mssql.pymssql",
+  "databricks",
+  "databricks.sql",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--tb=native --strict-markers"
+testpaths = ["tests"]
 markers = [
     "integration: tests that use a database",
     "smoke: tests that run the cohort extractor in its container against a database",

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -5,6 +5,7 @@
 # pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 
 black
+databricks-cli
 docker
 flake8
 flake8-builtins

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -36,6 +36,7 @@ click==8.0.3 \
     --hash=sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b
     # via
     #   black
+    #   databricks-cli
     #   interrogate
     #   pip-tools
 colorama==0.4.4 \
@@ -77,6 +78,10 @@ coverage[toml]==6.0.1 \
     --hash=sha256:f398d38e6ebc2637863db1d7be3d4f9c5174e7d24bb3b0716cdb1f204669cbcf \
     --hash=sha256:f82a17f2a77958f3eef40ad385fc82d4c6ba9a77a51a174efe03ce75daebbc16
     # via pytest-cov
+databricks-cli==0.16.2 \
+    --hash=sha256:3e9a65a19a589b795ebbd9b3b16a8e470d612d57d6216ae44a9c7a735e4080e6 \
+    --hash=sha256:74c35b38fe686881af4b4797c4f3ab2e1c9e9ff4986f470486f152fb45d19b24
+    # via -r requirements.dev.in
 distlib==0.3.3 \
     --hash=sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31 \
     --hash=sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05
@@ -336,13 +341,16 @@ regex==2021.10.8 \
 requests==2.26.0 \
     --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
     --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
-    # via docker
+    # via
+    #   databricks-cli
+    #   docker
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   -c requirements.prod.txt
     #   -r requirements.dev.in
+    #   databricks-cli
     #   python-dateutil
     #   virtualenv
 sqlalchemy-stubs==0.4 \
@@ -352,7 +360,9 @@ sqlalchemy-stubs==0.4 \
 tabulate==0.8.9 \
     --hash=sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4 \
     --hash=sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7
-    # via interrogate
+    # via
+    #   databricks-cli
+    #   interrogate
 tokenize-rt==4.2.1 \
     --hash=sha256:08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8 \
     --hash=sha256:0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -4,9 +4,15 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.prod.txt pyproject.toml
 #
+databricks-sql-connector==0.9.1 \
+    --hash=sha256:5774e3d506b352566621e7bd5d9c19a80e92d7cd3876be0fab94c52640b612cd \
+    --hash=sha256:d83b7cc55e3b34ac416df6f5466aa2b9a1142787425a58015cca6a90efbea56e
+    # via cohortextractor2 (pyproject.toml)
 future==0.18.2 \
     --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
-    # via pyhive
+    # via
+    #   databricks-sql-connector
+    #   pyhive
 greenlet==1.1.2 \
     --hash=sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711 \
     --hash=sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd \
@@ -168,6 +174,7 @@ python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
     # via
+    #   databricks-sql-connector
     #   pandas
     #   pyhive
 pytz==2021.3 \
@@ -224,4 +231,6 @@ structlog==21.2.0 \
     # via cohortextractor2 (pyproject.toml)
 thrift==0.15.0 \
     --hash=sha256:87c8205a71cf8bbb111cb99b1f7495070fbc9cabb671669568854210da5b3e29
-    # via cohortextractor2 (pyproject.toml)
+    # via
+    #   cohortextractor2 (pyproject.toml)
+    #   databricks-sql-connector

--- a/scripts/dbx
+++ b/scripts/dbx
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+import configparser
+import json
+import os
+import subprocess
+import sys
+import time
+
+import click
+import requests
+
+CLUSTERS = None
+ORGID = None
+USERNAME = None
+PASSWORD = None
+COMMANDS = {}
+OUTPUT = True
+
+
+# https://docs.databricks.com/dev-tools/api/latest/clusters.html#create
+CLUSTER_REQUEST = {
+    "cluster_name": "test",
+    "spark_version": "9.1.x-scala2.12",
+    "spark_conf": {
+        "spark.sql.legacy.allowCreatingManagedTableUsingNonemptyLocation": "true",
+    },
+    "aws_attributes": {
+        "zone_id": "auto",
+        "first_on_demand": 0,
+        "availability": "ON_DEMAND",
+        "spot_bid_price_percent": 100,
+    },
+    "node_type_id": "dev-tier-node",
+    "driver_node_type_id": "dev-tier-node",
+    "spark_env_vars": {
+        "PYSPARK_PYTHON": "/databricks/python3/bin/python3",
+    },
+    "autotermination_minutes": 120,
+    "enable_elastic_disk": False,
+    "disk_spec": {
+        "disk_count": 0,
+    },
+    "enable_local_disk_encryption": False,
+    "instance_source": {
+        "node_type_id": "dev-tier-node",
+    },
+    "driver_instance_source": {
+        "node_type_id": "dev-tier-node",
+    },
+    "num_workers": 0,
+}
+
+
+def run(cmd, check=True, text=True, **kwargs):
+    echo(" ".join(cmd).replace(PASSWORD, "*****"))
+    return subprocess.run(cmd, check=check, text=text, **kwargs)
+
+
+def echo(*args, **kwargs):
+    if OUTPUT:
+        click.echo(*args, **kwargs)
+
+
+class Cluster:
+    def __init__(self, data):
+        self.data = data
+
+    @property
+    def cluster_id(self):
+        return self.data["cluster_id"]
+
+    @property
+    def state(self):
+        return self.data["state"]
+
+    @property
+    def url(self):
+        return f"https://{USERNAME}:{PASSWORD}@community.cloud.databricks.com/default?http_path=sql/protocolv1/o/{ORGID}/{self.cluster_id}"
+
+    def __str__(self):
+        return f"{self.cluster_id}: {self.state}"
+
+
+def get_auth():
+    global USERNAME, PASSWORD
+    path = os.path.expanduser("~/.databrickscfg")
+    if not os.path.exists(path):
+        sys.exit(
+            "databricks cli has not been configured. Run:\n"
+            "databricks configure --host https://community.cloud.databricks.com"
+        )
+    parser = configparser.ConfigParser()
+    parser.read(path)
+    default = parser["DEFAULT"]
+    USERNAME = default["username"]
+    PASSWORD = default["password"]
+
+
+def get_clusters():
+    # we hit the API directly here, as we need access to the headers.
+    global CLUSTERS, ORGID
+
+    resp = requests.get(
+        "https://community.cloud.databricks.com/api/2.0/clusters/list",
+        auth=(USERNAME, PASSWORD),
+    )
+    resp.raise_for_status()
+
+    CLUSTERS = {c["cluster_name"]: Cluster(c) for c in resp.json().get("clusters", {})}
+    ORGID = resp.headers["X-Databricks-Org-Id"]
+
+
+def _teardown(name):
+    if name not in CLUSTERS:
+        return
+
+    c = CLUSTERS[name]
+    echo(f"Tearing down {c}...")
+    run(["databricks", "clusters", "permanent-delete", "--cluster-id", c.cluster_id])
+
+
+def _wait(name, timeout=90):
+    echo(CLUSTERS[name])
+    start = time.time()
+    while CLUSTERS[name].state == "PENDING":
+        if time.time() - start > timeout:
+            sys.exit(f"timed out after {timeout}s waiting for cluster {name}")
+        time.sleep(10)
+        get_clusters()
+        echo(CLUSTERS[name])
+
+
+@click.group()
+def cli():
+    pass
+
+
+# common option
+name_option = click.option("--name", default="test", help="name of cluster")
+
+
+@cli.command()
+@name_option
+def teardown(name):
+    """Teardown current cluster."""
+    _teardown(name)
+
+
+@cli.command()
+@name_option
+@click.option(
+    "--wait/--no-wait",
+    default=False,
+    help="wait for cluster to be available before exiting",
+)
+@click.option("--timeout", default=90, help="timeout to wait if --wait is passed")
+@click.option(
+    "--output-url/--no-output-url", default=False, help="only output the connection url"
+)
+def create(name, wait, output_url, timeout):
+    """Create a new cluster."""
+    global OUTPUT
+    if output_url:
+        OUTPUT = False
+
+    c = CLUSTERS.get(name)
+    if c and c.state == "RUNNING":
+        if output_url:
+            click.echo(c.url)
+        else:
+            echo(c)
+        return
+
+    _teardown(name)
+    request = CLUSTER_REQUEST.copy()
+    request["cluster_name"] = name
+    request_json = json.dumps(request)
+    run(
+        ["databricks", "clusters", "create", "--json-file", "/dev/stdin"],
+        input=request_json,
+        capture_output=output_url,
+    )
+    get_clusters()
+
+    if wait:
+        _wait(name, timeout)
+
+    if output_url:
+        click.echo(CLUSTERS[name].url)
+    else:
+        echo(CLUSTERS[name])
+
+
+@cli.command()
+@name_option
+def wait(name):
+    """Wait until cluster is available."""
+    _wait(name)
+
+
+@cli.command()
+@name_option
+def url(name):
+    """Print connection string."""
+    c = CLUSTERS.get(name)
+    if c:
+        click.echo(c.url)
+    else:
+        click.echo(f"No cluster named {name}")
+
+
+@cli.command()
+@name_option
+def test(name):
+    """Test cluster up and working."""
+    _wait(name)
+    c = CLUSTERS[name]
+    run(
+        [
+            "python",
+            "-m",
+            "cohortextractor",
+            "test_connection",
+            "-b",
+            "databricks",
+            "-u",
+            c.url,
+        ]
+    )
+
+
+@cli.command()
+@name_option
+def status(name):
+    """Print cluster status."""
+    click.echo(CLUSTERS[name])
+
+
+if __name__ == "__main__":
+    get_auth()
+    get_clusters()
+    cli()

--- a/tests/lib/databricks_schema.py
+++ b/tests/lib/databricks_schema.py
@@ -2,6 +2,9 @@ import sqlalchemy.orm
 import sqlalchemy.types
 from sqlalchemy import DDL, Column, Date, Integer, Text, event
 
+# generate surrogate PK ids ourselves, as spark doesn't support auto id
+next_id = iter(range(1, 2 ** 63)).__next__
+
 Base = sqlalchemy.orm.declarative_base()
 
 # ** NOTE ON PRIMARY KEYS **
@@ -14,10 +17,10 @@ class PCareMeds(Base):
     __tablename__ = "pcaremeds"
     __table_args__ = {"schema": "PCAREMEDS"}
 
-    Person_ID = Column(Integer, primary_key=True)
+    Person_ID = Column(Integer, primary_key=True, default=next_id)
     PatientDoB = Column(Date)
-    PrescribeddmdCode = Column(Text(collation="Latin1_General_BIN"), primary_key=True)
-    ProcessingPeriodDate = Column(Date, primary_key=True)
+    PrescribeddmdCode = Column(Text(collation="Latin1_General_BIN"))
+    ProcessingPeriodDate = Column(Date)
 
 
 class MPSHESApc(Base):

--- a/tests/lib/databricks_schema.py
+++ b/tests/lib/databricks_schema.py
@@ -17,7 +17,10 @@ class PCareMeds(Base):
     __tablename__ = "pcaremeds"
     __table_args__ = {"schema": "PCAREMEDS"}
 
-    Person_ID = Column(Integer, primary_key=True, default=next_id)
+    # fake PK to satisfy Sqlalchemy ORM
+    pk = Column(Integer, primary_key=True, default=next_id)
+
+    Person_ID = Column(Integer)
     PatientDoB = Column(Date)
     PrescribeddmdCode = Column(Text(collation="Latin1_General_BIN"))
     ProcessingPeriodDate = Column(Date)
@@ -27,15 +30,21 @@ class MPSHESApc(Base):
     __tablename__ = "hes_apc_1920"
     __table_args__ = {"schema": "HES_AHAS_MPS"}
 
-    PERSON_ID = Column(Integer, primary_key=True)
-    EPIKEY = Column(Integer, primary_key=True)
+    # fake PK to satisfy Sqlalchemy ORM
+    pk = Column(Integer, primary_key=True, default=next_id)
+
+    PERSON_ID = Column(Integer)
+    EPIKEY = Column(Integer)
 
 
 class HESApc(Base):
     __tablename__ = "hes_apc_1920"
     __table_args__ = {"schema": "HES_AHAS"}
 
-    EPIKEY = Column(Integer, primary_key=True)
+    # fake PK to satisfy Sqlalchemy ORM
+    pk = Column(Integer, primary_key=True, default=next_id)
+
+    EPIKEY = Column(Integer)
     ADMIDATE = Column(Date)
     DIAG_4_01 = Column(Text(collation="Latin1_General_BIN"))
     ADMIMETH = Column(Integer)
@@ -46,8 +55,15 @@ class HESApcOtr(Base):
     __tablename__ = "hes_apc_otr_1920"
     __table_args__ = {"schema": "HES_AHAS"}
 
-    EPIKEY = Column(Integer, primary_key=True)
+    # fake PK to satisfy Sqlalchemy ORM
+    pk = Column(Integer, primary_key=True, default=next_id)
+
+    EPIKEY = Column(Integer)
     SUSSPELLID = Column(Integer)
+
+
+# Note: this code could be make generic to add schema drop/create support to
+# any ORM Base, perhaps
 
 
 def _get_schemas(base):


### PR DESCRIPTION
This adds support for using the recommended databricks-sql-connector DBAPI when talking to an actual databricks instance.

It extends the test tooling to be able to run against an actual Databricks instance, locally and in CI.