### PR TITLE
Extract Contract Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ htmlcov
 # Virtual environments
 .venv/
 venv/
+
+# Docs
+backend_docs.json

--- a/Justfile
+++ b/Justfile
@@ -97,8 +97,17 @@ check: devenv
     $BIN/pyupgrade --py39-plus --keep-percent-format \
         $(find cohortextractor2 -name "*.py" -type f) \
         $(find tests -name "*.py" -type f)
+    just docstrings
     $BIN/mypy
 
+# ensure our public facing docstrings exist so we can build docs from them
+docstrings: devenv
+    $BIN/pydocstyle cohortextractor2/backends/databricks.py
+    $BIN/pydocstyle cohortextractor2/backends/graphnet.py
+    $BIN/pydocstyle cohortextractor2/backends/tpp.py
+
+    # only enforce classes are documented for the public facing docs
+    $BIN/pydocstyle --add-ignore=D102,D103,D105,D106 cohortextractor2/concepts/tables.py
 
 # runs the format (black) and sort (isort) checks and fixes the files
 fix: devenv

--- a/cohortextractor2/__main__.py
+++ b/cohortextractor2/__main__.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser, ArgumentTypeError
 from pathlib import Path
 
 from .backends import BACKENDS
+from .docs import generate_docs
 from .main import (
     generate_cohort,
     generate_measures,
@@ -56,6 +57,8 @@ def main(args=None):
             backend=options.backend,
             url=options.url,
         )
+    elif options.which == "generate_docs":
+        generate_docs()
     elif options.which == "print_help":
         parser.print_help()
     else:
@@ -151,6 +154,12 @@ def build_parser():
         help="db url",
         default=os.environ.get("DATABASE_URL"),
     )
+
+    generate_docs = subparsers.add_parser(
+        "generate_docs",
+        help="Generate a JSON representation of the data needed for the public documentation of Backends and Contracts",
+    )
+    generate_docs.set_defaults(which="generate_docs")
 
     return parser
 

--- a/cohortextractor2/backends/databricks.py
+++ b/cohortextractor2/backends/databricks.py
@@ -3,6 +3,8 @@ from .base import BaseBackend, Column, MappedTable, QueryTable
 
 
 class DatabricksBackend(BaseBackend):
+    """Backend for working with data in Databricks."""
+
     backend_id = "databricks"
     query_engine_class = SparkQueryEngine
     patient_join_column = "patient_id"

--- a/cohortextractor2/backends/graphnet.py
+++ b/cohortextractor2/backends/graphnet.py
@@ -3,6 +3,8 @@ from .base import BaseBackend, Column, MappedTable
 
 
 class GraphnetBackend(BaseBackend):
+    """Backend for working with data in Graphnet."""
+
     backend_id = "graphnet"
     query_engine_class = MssqlQueryEngine
     patient_join_column = "Patient_ID"

--- a/cohortextractor2/backends/tpp.py
+++ b/cohortextractor2/backends/tpp.py
@@ -5,14 +5,21 @@ from .base import BaseBackend, Column, MappedTable, QueryTable
 
 def rtrim(ref, char):
     """
-    MSSQL's {L,R}TRIM() functions (unlike TRIM()) don't allow trimming of arbitrary characters, only spaces. So we've
-    implemented it here. Note that this won't work as-is for '^' or ']', but they could be supported with a bit of
-    escaping.
-        * Since we're using PATINDEX(), which only works from the front of the string, we REVERSE() the
-          string every time we refer to it and then re-REVERSE() the result once we're done.
-        * We search through the string to find the index of the first character that isn't the thing we're stripping.
-        * Then we work out the length of the string remaining from that point to the end.
-        * Finally we take a substring from the index to the end of the string.
+    Right trim arbitrary characters.
+
+    MSSQL's {L,R}TRIM() functions (unlike TRIM()) don't allow trimming of
+    arbitrary characters, only spaces. So we've implemented it here. Note that
+    this won't work as-is for '^' or ']', but they could be supported with a
+    bit of escaping.
+
+      * Since we're using PATINDEX(), which only works from the front of the
+        string, we REVERSE() the string every time we refer to it and then
+        re-REVERSE() the result once we're done.
+      * We search through the string to find the index of the first character
+        that isn't the thing we're stripping.
+      * Then we work out the length of the string remaining from that point to
+        the end.
+      * Finally we take a substring from the index to the end of the string.
 
     (LTRIM() could be implemented in the same way, but without all the reversing.)
     """
@@ -34,9 +41,14 @@ def rtrim(ref, char):
 
 def string_split(ref, delim):
     """
-    The compatibility level that TPP runs SQL Server at doesn't include the `STRING_SPLIT()` function, so we implement
-    it here ourselves. This use of SQL Server's XML-handling capabilities is truly ugly, but it allows us to implement
-    this inline so we don't need to define a function. Implementation copied from
+    Split strings on the given delimiter.
+
+    The compatibility level that TPP runs SQL Server at doesn't include the
+    `STRING_SPLIT()` function, so we implement it here ourselves. This use of
+    SQL Server's XML-handling capabilities is truly ugly, but it allows us to
+    implement this inline so we don't need to define a function.
+
+    Implementation copied from
     https://sqlperformance.com/2012/07/t-sql-queries/split-strings.
     """
     return f"""

--- a/cohortextractor2/backends/tpp.py
+++ b/cohortextractor2/backends/tpp.py
@@ -66,6 +66,8 @@ def string_split(ref, delim):
 
 
 class TPPBackend(BaseBackend):
+    """Backend for working with data in TPP."""
+
     backend_id = "tpp"
     query_engine_class = MssqlQueryEngine
     patient_join_column = "Patient_ID"

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -23,9 +23,7 @@ class PracticeRegistrations(EventFrame):
 
 
 class PatientDemographics(TableContract):
-    """
-    Provides demographic information about patients
-    """
+    """Provides demographic information about patients."""
 
     patient_id = Column(
         type=types.PseudoPatientId(),

--- a/cohortextractor2/concepts/tables.py
+++ b/cohortextractor2/concepts/tables.py
@@ -6,6 +6,12 @@ from .table_contract import Column, TableContract
 
 
 class ClinicalEvents(EventFrame):
+    """
+    Clinical events recorded by GPs.
+
+    Ideally a record of all relevant clinical events with their code and date.
+    """
+
     code = "code"
     date = "date"
 
@@ -14,6 +20,13 @@ class ClinicalEvents(EventFrame):
 
 
 class PracticeRegistrations(EventFrame):
+    """
+    For backends with primary care data, the patient's registered practice.
+
+    Ideally a record of all relevant registrations with their start and end
+    date, or the latest registered practice.
+    """
+
     patient_id = "patient_id"
     date_start = "date_start"
     date_end = "date_end"

--- a/cohortextractor2/docs.py
+++ b/cohortextractor2/docs.py
@@ -1,0 +1,59 @@
+import json
+import operator
+
+from .backends.base import BaseBackend
+from .concepts.tables import ClinicalEvents, PatientDemographics, PracticeRegistrations
+
+
+def _build_backends():
+    backends = sorted(BaseBackend.__subclasses__(), key=operator.attrgetter("__name__"))
+
+    for backend in backends:
+        tables = [getattr(backend, name) for name in backend.tables]
+        tables = [table.implements.__name__ for table in tables if table.implements]
+        yield {
+            "name": backend.__name__,
+            "tables": tables,
+        }
+
+
+def _build_contracts():
+    """Build a dict representation for each Contract"""
+    # TODO: investigate using TableContract.__subclasses__() to build this list
+    # dynamically
+    contracts = [
+        ClinicalEvents,
+        PatientDemographics,
+        PracticeRegistrations,
+    ]
+
+    for contract in contracts:
+        docstring = _reformat_docstring(contract.__doc__)
+        dotted_path = f"{contract.__module__}.{contract.__qualname__}"
+
+        yield {
+            "name": contract.__name__,
+            "dotted_path": dotted_path,
+            "docstring": docstring,
+            "columns": [],
+            "contract_support": [],
+        }
+
+
+def _reformat_docstring(d):
+    """Reformat docstring to make it easier to use in a markdown/HTML document."""
+    docstring = d.strip()
+
+    return [line.strip() for line in docstring.split("\n")]
+
+
+def generate_docs():
+    data = {
+        "contracts": list(_build_contracts()),
+        "backends": list(_build_backends()),
+    }
+
+    with open("backend_docs.json", "w") as f:
+        json.dump(data, f, indent=2)
+
+    print("Generated data for backends")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,20 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.pydocstyle]
+convention = "google"
+add_select = [
+  "D213",
+]
+# base ignores for all docstrings, for module/package specific ones add them to
+#the CLI args in Justfile
+add_ignore = [
+  "D100",
+  "D104",
+  "D107",
+  "D212",
+]
+
 [tool.pytest.ini_options]
 addopts = "--tb=native --strict-markers"
 testpaths = ["tests"]

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -17,6 +17,7 @@ mypy
 pandas-stubs
 pip-tools
 pre-commit
+pydocstyle[toml]
 pytest
 pytest-cov
 pytest-freezegun

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -226,6 +226,10 @@ pycodestyle==2.8.0 \
     --hash=sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20 \
     --hash=sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f
     # via flake8
+pydocstyle[toml]==6.1.1 \
+    --hash=sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc \
+    --hash=sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4
+    # via -r requirements.dev.in
 pyflakes==2.4.0 \
     --hash=sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c \
     --hash=sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e
@@ -353,6 +357,10 @@ six==1.16.0 \
     #   databricks-cli
     #   python-dateutil
     #   virtualenv
+snowballstemmer==2.2.0 \
+    --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
+    --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
+    # via pydocstyle
 sqlalchemy-stubs==0.4 \
     --hash=sha256:5eec7aa110adf9b957b631799a72fef396b23ff99fe296df726645d01e312aa5 \
     --hash=sha256:c665d6dd4482ef642f01027fa06c3d5e91befabb219dc71fc2a09e7d7695f7ae
@@ -374,6 +382,7 @@ toml==0.10.2 \
     #   interrogate
     #   mypy
     #   pre-commit
+    #   pydocstyle
     #   pytest
 tomli==1.2.1 \
     --hash=sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f \

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -64,6 +64,17 @@ def test_generate_cohort_without_database_url_or_dummy_data(capsys, tmp_path):
     )
 
 
+def test_generate_docs(mocker):
+    patched = mocker.patch("cohortextractor2.__main__.generate_docs")
+
+    argv = [
+        "generate_docs",
+    ]
+    main(argv)
+
+    patched.assert_called_once()
+
+
 def test_validate_cohort(mocker, tmp_path):
     # Verify that the validate_cohort subcommand can be invoked.
     patched = mocker.patch("cohortextractor2.__main__.run_cohort_action")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,35 @@
+import json
+
+from cohortextractor2.docs import _reformat_docstring, generate_docs
+
+
+def test_reformat_docstring():
+    docstring = """
+    First line.
+
+    Second line.
+    """
+
+    output = _reformat_docstring(docstring)
+
+    expected = [
+        "First line.",
+        "",
+        "Second line.",
+    ]
+    assert output == expected
+
+
+def test_generate_docs():
+    generate_docs()
+
+    with open("backend_docs.json") as f:
+        data = json.load(f)
+
+    expected = {"DatabricksBackend", "GraphnetBackend", "TPPBackend"}
+    output = {b["name"] for b in data["backends"]}
+    assert expected <= output
+
+    assert data["contracts"][0]["name"] == "ClinicalEvents"
+    assert data["contracts"][1]["name"] == "PatientDemographics"
+    assert data["contracts"][2]["name"] == "PracticeRegistrations"


### PR DESCRIPTION
This sets up pydocstyle and configures where to run it in the justfile so that our backends and contracts have docstrings in the correct format.

It also adds a command, `generate_docs`, to produce a JSON representation of the backends and contracts for the [mkdocs-opensafely-backend-contracts](https://github.com/opensafely-core/mkdocs-opensafely-backend-contracts/) plugin to consume.  This command only provides names and docstrings for contracts, and names and tables for backends currently, but is intended to provide the extra information required for the rest of the docs page the plugin will render later.