### PR TITLE
Set minimum python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
   "pandas",
   "sqlalchemy",


### PR DESCRIPTION
Now we're not expecting to install this into the documentation repo (which is tied to 3.7) we can set `requires-python` to the correct minimum version.  We're using dictionary unions so that means 3.9 for us.