### PR TITLE
Add Rounding Methods

### DIFF
--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -53,6 +53,7 @@ from .query_language import (
     Codelist,
     Comparator,
     RoundToFirstOfMonth,
+    RoundToFirstOfYear,
     Row,
     Value,
     ValueFromAggregate,
@@ -283,6 +284,9 @@ class PatientSeries:
 
     def round_to_first_of_month(self):
         return PatientSeries(RoundToFirstOfMonth(self.value))
+
+    def round_to_first_of_year(self):
+        return PatientSeries(RoundToFirstOfYear(self.value))
 
 
 class Predicate:

--- a/databuilder/dsl.py
+++ b/databuilder/dsl.py
@@ -30,7 +30,9 @@ railway diagram:
                      |                            |
                      | select_column              |
                      V                            |
-               PatientSeries <--------------------+
+          +--> PatientSeries <--------------------+
+  round_X |          |
+          +----------+
 
 To support providing helpful error messages, we can implement __getattr__ on each class.
 This will intercept any lookup of a missing attribute, so that if eg a user tries to
@@ -50,6 +52,7 @@ from .query_language import (
     BaseTable,
     Codelist,
     Comparator,
+    RoundToFirstOfMonth,
     Row,
     Value,
     ValueFromAggregate,
@@ -277,6 +280,9 @@ class PatientSeries:
 
     def __hash__(self) -> int:
         return hash(repr(self.value))
+
+    def round_to_first_of_month(self):
+        return PatientSeries(RoundToFirstOfMonth(self.value))
 
 
 class Predicate:

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -18,6 +18,7 @@ from ..query_language import (
     FilteredTable,
     QueryNode,
     RoundToFirstOfMonth,
+    RoundToFirstOfYear,
     Row,
     Table,
     Value,
@@ -426,6 +427,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         class_method_map = {
             DateDifferenceInYears: self.date_difference_in_years,
             RoundToFirstOfMonth: self.round_to_first_of_month,
+            RoundToFirstOfYear: self.round_to_first_of_year,
         }
 
         assert value.__class__ in class_method_map, f"Unsupported function: {value}"
@@ -461,6 +463,9 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         return type_coerce(date_diff, sqlalchemy_types.Integer())
 
     def round_to_first_of_month(self, date):
+        raise NotImplementedError
+
+    def round_to_first_of_year(self, date):
         raise NotImplementedError
 
     def apply_aggregates(self, query, aggregate_nodes):

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -17,6 +17,7 @@ from ..query_language import (
     DateDifferenceInYears,
     FilteredTable,
     QueryNode,
+    RoundToFirstOfMonth,
     Row,
     Table,
     Value,
@@ -422,7 +423,10 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         #   def my_handle_fun(...)
         #
         # but the simple thing will do for now.
-        class_method_map = {DateDifferenceInYears: self.date_difference_in_years}
+        class_method_map = {
+            DateDifferenceInYears: self.date_difference_in_years,
+            RoundToFirstOfMonth: self.round_to_first_of_month,
+        }
 
         assert value.__class__ in class_method_map, f"Unsupported function: {value}"
 
@@ -455,6 +459,9 @@ class BaseSQLQueryEngine(BaseQueryEngine):
             else_=year_diff - 1,
         )
         return type_coerce(date_diff, sqlalchemy_types.Integer())
+
+    def round_to_first_of_month(self, date):
+        raise NotImplementedError
 
     def apply_aggregates(self, query, aggregate_nodes):
         """

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -1,5 +1,9 @@
 import contextlib
 
+import sqlalchemy
+from sqlalchemy.sql.expression import type_coerce
+
+from .. import sqlalchemy_types
 from .base_sql import BaseSQLQueryEngine
 from .mssql_dialect import MSSQLDialect
 from .mssql_lib import fetch_results_in_batches, write_query_to_table
@@ -61,3 +65,14 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
             # the normal manner
             with super().execute_query() as results:
                 yield results
+
+    def round_to_first_of_month(self, date):
+        date = type_coerce(date, sqlalchemy_types.Date())
+
+        first_of_month = sqlalchemy.func.datefromparts(
+            sqlalchemy.func.year(date),
+            sqlalchemy.func.month(date),
+            1,
+        )
+
+        return type_coerce(first_of_month, sqlalchemy_types.Date())

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -76,3 +76,14 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
         )
 
         return type_coerce(first_of_month, sqlalchemy_types.Date())
+
+    def round_to_first_of_year(self, date):
+        date = type_coerce(date, sqlalchemy_types.Date())
+
+        first_of_year = sqlalchemy.func.datefromparts(
+            sqlalchemy.func.year(date),
+            1,
+            1,
+        )
+
+        return type_coerce(first_of_year, sqlalchemy_types.Date())

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -78,3 +78,13 @@ class SparkQueryEngine(BaseSQLQueryEngine):
             date,
         )
         return type_coerce(first_of_month, sqlalchemy_types.Date())
+
+    def round_to_first_of_year(self, date):
+        date = type_coerce(date, sqlalchemy_types.Date())
+
+        first_of_year = sqlalchemy.func.date_trunc(
+            "YEAR",
+            date,
+        )
+
+        return type_coerce(first_of_year, sqlalchemy_types.Date())

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -3,8 +3,9 @@ import secrets
 
 import sqlalchemy
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql.expression import ClauseElement, Executable
+from sqlalchemy.sql.expression import ClauseElement, Executable, type_coerce
 
+from .. import sqlalchemy_types
 from .base_sql import BaseSQLQueryEngine
 from .spark_dialect import SparkDialect
 
@@ -68,3 +69,12 @@ class SparkQueryEngine(BaseSQLQueryEngine):
             table = sqlalchemy.Table(table_name, sqlalchemy.MetaData())
             query = sqlalchemy.schema.DropTable(table, if_exists=True)
             cursor.execute(query)
+
+    def round_to_first_of_month(self, date):
+        date = type_coerce(date, sqlalchemy_types.Date())
+
+        first_of_month = sqlalchemy.func.date_trunc(
+            "MONTH",
+            date,
+        )
+        return type_coerce(first_of_month, sqlalchemy_types.Date())

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -403,3 +403,7 @@ class ValueFromFunction(Value):
 
 class DateDifferenceInYears(ValueFromFunction):
     pass
+
+
+class RoundToFirstOfMonth(ValueFromFunction):
+    pass

--- a/databuilder/query_language.py
+++ b/databuilder/query_language.py
@@ -407,3 +407,7 @@ class DateDifferenceInYears(ValueFromFunction):
 
 class RoundToFirstOfMonth(ValueFromFunction):
     pass
+
+
+class RoundToFirstOfYear(ValueFromFunction):
+    pass


### PR DESCRIPTION
This adds the rounding methods `round_to_first_of_month` and `round_to_first_of_year` to PatientSeries, with implementations for both mssql and spark query engines.

We went with query engine specific implementations because we couldn't see a way to make the changes in a generic way.