### PR TITLE
refactor: Refactor temp table creation and cleanup

### DIFF
--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -55,6 +55,14 @@ def get_primary_table(query):
     return get_joined_tables(query)[0]
 
 
+class MissingString(str):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        raise NotImplementedError(self.message)
+
+
 class BaseSQLQueryEngine(BaseQueryEngine):
 
     sqlalchemy_dialect: type[Dialect]
@@ -64,6 +72,9 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     # Per-instance cache for SQLAlchemy Engine
     _engine: Optional[sqlalchemy.engine.Engine] = None
+
+    # Force subclasses to define this
+    temp_table_prefix: str = MissingString("'temp_table_prefix' is undefined")
 
     def get_queries(self):
         """Build the list of SQL queries to execute"""
@@ -271,7 +282,7 @@ class BaseSQLQueryEngine(BaseQueryEngine):
         within this session; it's this function's responsibility to ensure it
         doesn't clash with any concurrent extracts
         """
-        raise NotImplementedError()
+        return f"{self.temp_table_prefix}{table_name}"
 
     def get_temp_database(self):
         """Which schema/database should we write temporary tables to."""

--- a/databuilder/query_engines/base_sql.py
+++ b/databuilder/query_engines/base_sql.py
@@ -120,8 +120,17 @@ class BaseSQLQueryEngine(BaseQueryEngine):
 
     def post_execute_cleanup(self, cursor):
         """
-        A no-op by default but subclasses can implement cleanup logic here
+        Called after results have been fetched
         """
+        for table in self.temp_tables.keys():
+            self.drop_temp_table(cursor, table)
+
+    def drop_temp_table(self, cursor, table):
+        """
+        Drop the specified temporary table
+        """
+        query = sqlalchemy.schema.DropTable(table, if_exists=True)
+        cursor.execute(query)
 
     #
     # QUERY DAG METHODS AND NODE INTERACTION

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -57,6 +57,12 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
             with super().execute_query() as results:
                 yield results
 
+    def drop_temp_table(self, cursor, table):
+        # The `#` prefix is an MSSQL-ism which automatically makes the tables
+        # session-scoped temporary tables which therefore don't require cleanup
+        if not table.name.startswith("#"):
+            super().cleanup_temp_table(cursor, table)  # pragma: no cover
+
     def round_to_first_of_month(self, date):
         date = type_coerce(date, sqlalchemy_types.Date())
 

--- a/databuilder/query_engines/mssql.py
+++ b/databuilder/query_engines/mssql.py
@@ -17,25 +17,16 @@ class MssqlQueryEngine(BaseSQLQueryEngine):
     # https://docs.microsoft.com/en-us/sql/t-sql/queries/table-value-constructor-transact-sql?view=sql-server-ver15#limitations-and-restrictions
     max_rows_per_insert = 999
 
+    # The `#` prefix is an MSSQL-ism which automatically makes the tables session-scoped
+    # temporary tables
+    temp_table_prefix = "#"
+
     def write_query_to_table(self, table, query):
         """
         Returns a new query which, when executed, writes the results of `query`
         into `table`
         """
         return write_query_to_table(table, query)
-
-    def get_temp_table_name(self, table_name):
-        """
-        Return a table name based on `table_name` but suitable for use as a
-        temporary table.
-
-        It's the caller's responsibility to ensure `table_name` is unique
-        within this session; it's this function's responsibility to ensure it
-        doesn't clash with any concurrent extracts
-        """
-        # The `#` prefix makes this a session-scoped temporary table which
-        # automatically gives us the isolation we need
-        return f"#{table_name}"
 
     @contextlib.contextmanager
     def execute_query(self):

--- a/databuilder/query_engines/spark.py
+++ b/databuilder/query_engines/spark.py
@@ -49,14 +49,6 @@ class SparkQueryEngine(BaseSQLQueryEngine):
     def get_temp_database(self):
         return self.backend.temporary_database
 
-    def post_execute_cleanup(self, cursor):
-        """
-        Called after results have been fetched
-        """
-        for table in self.temp_tables.keys():
-            query = sqlalchemy.schema.DropTable(table, if_exists=True)
-            cursor.execute(query)
-
     def round_to_first_of_month(self, date):
         date = type_coerce(date, sqlalchemy_types.Date())
 


### PR DESCRIPTION
This means we now automatically do the right thing when our temp tables live in a different database from our data tables (as they do in Spark) and, in general, this moves more of the logic to the base class rather than relying on individual query engines to implement things.

Some of the changes here might not immediately make sense on their own, but they turn out to simplify other refactors further down the road.